### PR TITLE
ci(ai-review): forward LINTRO_AI_MAX_COST_USD repo variable

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -21,11 +21,14 @@ name: AI Review - Dogfood
 # authenticates only against an API key, which is precisely the credential that
 # does not work for the Anthropic dogfood (#1838).
 #
-# Spend ceiling is the committed `ai.max_cost_usd: 2.00` in `.lintro-config.yaml`
-# (the empirically validated value from #1976/#1977; the 0.50 that landed with
-# #2018 / 9f43a98a was a side-effect, restored here by #2025). Under the CLI
-# transport the call bills the subscription, so the figure is advisory rather
-# than enforced spend control (#1923).
+# Spend ceiling defaults to the committed `ai.max_cost_usd: 2.00` in
+# `.lintro-config.yaml` (the empirically validated value from #1976/#1977; the
+# 0.50 that landed with #2018 / 9f43a98a was a side-effect, restored here by
+# #2025), overridable per-repo via the `LINTRO_AI_MAX_COST_USD` Actions
+# variable (#2024) so large multi-chunk PRs can complete instead of posting a
+# partial review every round. Under the CLI transport the call bills the
+# subscription, so the figure is advisory rather than enforced spend control
+# (#1923).
 #
 # Posts a review comment: the review runs with `--post`, so lintro maintains a
 # single sticky comment on the PR (rich findings + cumulative telemetry) and
@@ -280,3 +283,9 @@ jobs:
           LINTRO_AI_TRANSPORT: ${{ vars.LINTRO_AI_TRANSPORT || 'cli' }}
           LINTRO_AI_PROVIDER: ${{ vars.LINTRO_AI_PROVIDER || 'anthropic' }}
           LINTRO_AI_MODEL: ${{ vars.LINTRO_AI_MODEL }}
+          # Spend ceiling override (#2024). Unset falls through to the
+          # committed `ai.max_cost_usd: 2.00`, which large PRs exhaust after
+          # 3-4 of ~14 chunks — the review then posts a partial result every
+          # round. `0` means uncapped; the CLI transport treats the cap as a
+          # runtime bound, not marginal dollars, under subscription auth.
+          LINTRO_AI_MAX_COST_USD: ${{ vars.LINTRO_AI_MAX_COST_USD }}

--- a/docs/github-integration.md
+++ b/docs/github-integration.md
@@ -72,15 +72,16 @@ log.
   `LINTRO_CLI_BARE: never` keeps `--bare` off the command line so the OAuth session is
   actually used (#1838). The CLI version is pinned in `docker/ai-tools.Dockerfile` and
   installed from npm at that exact version.
-- 💸 **Bounded spend (advisory under the CLI transport)** — `ai.max_cost_usd` comes from
-  the trusted base config, so a PR cannot raise the cap. It prices only the tokens
-  lintro billed itself, so on the `cli` transport — where the call bills the
-  subscription — it bounds lintro's own accounting rather than enforcing spend. Setting
-  a cap does **not** serialize provider calls: the budget checks and charges the ceiling
-  around each call rather than holding a lock across it, so budgeted chunk reviews still
-  run concurrently. The trade-off is that calls already in flight when the ceiling is
-  reached still finish, so the final total can overshoot `ai.max_cost_usd` by roughly
-  one round of concurrent calls.
+- 💸 **Bounded spend (advisory under the CLI transport)** — `ai.max_cost_usd` defaults
+  to the trusted base config, so a PR cannot raise the cap. Repository operators can
+  override that default with the `LINTRO_AI_MAX_COST_USD` Actions variable (`0` means
+  uncapped). It prices only the tokens lintro billed itself, so on the `cli` transport
+  — where the call bills the subscription — it bounds lintro's own accounting rather
+  than enforcing spend. Setting a cap does **not** serialize provider calls: the budget
+  checks and charges the ceiling around each call rather than holding a lock across it,
+  so budgeted chunk reviews still run concurrently. The trade-off is that calls already
+  in flight when the ceiling is reached still finish, so the final total can overshoot
+  `ai.max_cost_usd` by roughly one round of concurrent calls.
 - 🟡 **Loud but non-blocking** — the check is deliberately **not** required, but it is
   not unconditionally green either: it reddens whenever no review was produced (missing
   or dead credential, depleted balance, unreachable provider, lintro-side failure). See

--- a/docs/github-integration.md
+++ b/docs/github-integration.md
@@ -75,9 +75,9 @@ log.
 - 💸 **Bounded spend (advisory under the CLI transport)** — `ai.max_cost_usd` defaults
   to the trusted base config, so a PR cannot raise the cap. Repository operators can
   override that default with the `LINTRO_AI_MAX_COST_USD` Actions variable (`0` means
-  uncapped). It prices only the tokens lintro billed itself, so on the `cli` transport
-  — where the call bills the subscription — it bounds lintro's own accounting rather
-  than enforcing spend. Setting a cap does **not** serialize provider calls: the budget
+  uncapped). It prices only the tokens lintro billed itself, so on the `cli` transport —
+  where the call bills the subscription — it bounds lintro's own accounting rather than
+  enforcing spend. Setting a cap does **not** serialize provider calls: the budget
   checks and charges the ceiling around each call rather than holding a lock across it,
   so budgeted chunk reviews still run concurrently. The trade-off is that calls already
   in flight when the ceiling is reached still finish, so the final total can overshoot

--- a/docs/github-integration.md
+++ b/docs/github-integration.md
@@ -52,9 +52,8 @@ If you want to publish the weekly report to Pages, prefer using a dedicated
 
 **File:** `.github/workflows/ai-review.yml`
 
-py-lintro dogfoods its own `lintro review` command on pull requests that touch
-`lintro/**`. The workflow runs an AI diff review and prints the JSON result to the job
-log.
+py-lintro dogfoods its own `lintro review` command on every eligible pull request. The
+workflow runs an AI diff review and prints the JSON result to the job log.
 
 **Features:**
 

--- a/scripts/ci/run-ai-review.sh
+++ b/scripts/ci/run-ai-review.sh
@@ -59,6 +59,7 @@ set -euo pipefail
 #   LINTRO_AI_ENABLED       Master switch; the workflow sets this to 1.
 #   LINTRO_AI_PROVIDER      Optional overlay (workflow default: anthropic).
 #   LINTRO_AI_MODEL         Optional overlay (empty = provider/config default).
+#   LINTRO_AI_MAX_COST_USD  Optional spend ceiling overlay (empty = config default).
 #   LINTRO_AI_TRANSPORT     Optional overlay (workflow default: cli).
 #   GITHUB_STEP_SUMMARY     When set, the outcome is appended as Markdown.
 

--- a/tests/scripts/test_run_ai_review.py
+++ b/tests/scripts/test_run_ai_review.py
@@ -133,7 +133,7 @@ def test_committed_config_keeps_ai_off_with_review_ready() -> None:
 
 
 def test_workflow_feeds_lintro_ai_env_from_repo_variables() -> None:
-    """The review step overlays provider/model/transport from Actions variables."""
+    """The review step overlays AI settings from Actions variables."""
     loaded = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
     steps = loaded["jobs"]["ai-review"]["steps"]
     review_steps = [
@@ -149,6 +149,9 @@ def test_workflow_feeds_lintro_ai_env_from_repo_variables() -> None:
         "${{ vars.LINTRO_AI_PROVIDER || 'anthropic' }}",
     )
     assert_that(env["LINTRO_AI_MODEL"]).is_equal_to("${{ vars.LINTRO_AI_MODEL }}")
+    assert_that(env["LINTRO_AI_MAX_COST_USD"]).is_equal_to(
+        "${{ vars.LINTRO_AI_MAX_COST_USD }}",
+    )
     assert_that(env).does_not_contain_key("AI_REVIEW_MAX_COST_USD")
 
 


### PR DESCRIPTION
## What

Forward the `LINTRO_AI_MAX_COST_USD` Actions variable (env override from #2024) into the ai-review step, alongside the existing `LINTRO_AI_TRANSPORT/PROVIDER/MODEL` variables (#1971 pattern). Header comment updated to describe the override.

## Why

The committed `ai.max_cost_usd: 2.00` is the only spend ceiling CI sees. Large PRs (e.g. #1165, 14 chunks) exhaust it after 3-4 chunks; with deterministic chunk ordering, every re-review round burns the budget on the same leading chunks and re-posts the same partial findings — the tail chunks are never reviewed in any round. Agents then spend rounds re-verifying stale findings.

The repo variable is already set to `10` (inert until this merges — the workflow runs from the base ref, so this change takes effect on PRs reviewed after merge). Under CLI transport + subscription auth the cap is advisory (bounds runtime, not marginal dollars). Unset variable falls through to the committed 2.00, so local checkouts are unchanged.

Verified `transports.cli.max_cost_usd_advisory` defaults to `None`, so the override reaches the CLI-transport budget (`lintro/ai/transport.py`).

## Follow-up

#2154 — resume/skip already-reviewed chunks across rounds so capped reviews converge to full coverage instead of groundhog-daying the same chunks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that all eligible pull requests receive automated reviews.
  * Documented repository-level spending limit overrides using `LINTRO_AI_MAX_COST_USD`.
  * Explained that `0` disables the cap, CLI-based limits are advisory, and concurrent reviews may exceed the limit.

* **Chores**
  * Updated automated review workflows to pass the configured spending limit, using the committed default when no override is provided.
  * Added validation confirming the setting is populated correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->