### PR TITLE
feat(ai)!: file-level review resume and sticky redesign

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -335,11 +335,12 @@ jobs:
           LINTRO_AI_TRANSPORT: ${{ vars.LINTRO_AI_TRANSPORT || 'cli' }}
           LINTRO_AI_PROVIDER: ${{ vars.LINTRO_AI_PROVIDER || 'anthropic' }}
           LINTRO_AI_MODEL: ${{ vars.LINTRO_AI_MODEL }}
-          # Spend ceiling override (#2024). Unset falls through to the
-          # committed `ai.max_cost_usd: 2.00`, which large PRs exhaust after
-          # 3-4 of ~14 chunks — the review then posts a partial result every
-          # round. `0` means uncapped; the CLI transport treats the cap as a
-          # runtime bound, not marginal dollars, under subscription auth.
+          # Spend ceiling override (#2024 / #2154). Unset falls through to
+          # the committed `ai.max_cost_usd: 2.00`. Overlay `uncapped` lifts
+          # the ceiling; overlay `0` is rejected as ambiguous. YAML `0` is
+          # still a literal $0 cap. The CLI transport treats a numeric cap
+          # as a runtime bound, not marginal dollars, under subscription
+          # auth.
           LINTRO_AI_MAX_COST_USD: ${{ vars.LINTRO_AI_MAX_COST_USD }}
 
       - name: Upload review-state artifacts

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -198,7 +198,7 @@ jobs:
       - name: Locate prior review-state run
         # API listing, not download-artifact's same-run default. Extends
         # run-ai-review.sh so this is not a new script invocation (#2158).
-        # Empty run-id is the no-op: lintro does not write state yet.
+        # Empty run-id is the no-op: first review on a PR, or no valid prior.
         # continue-on-error keeps a locator failure from skipping the
         # review. The file-existence guard covers already-open PRs whose
         # base.sha still has the pre-plumbing run-ai-review.sh (that

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,17 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
+- **ai-review**: file-level resume, INCOMPLETE verdict, artifact-backed state, and
+  sticky redesign (#2154, #2157)
+
 ### Changed
 
 ### Deprecated
 
 ### Removed
+
+- **ai**: overlay `0` for `LINTRO_AI_MAX_COST_USD` / `--max-cost-usd` is rejected. Use
+  `uncapped`. YAML `0` remains a literal $0 cap.
 
 ### Fixed
 

--- a/docs/adr/0007-review-resume-and-artifact-state.md
+++ b/docs/adr/0007-review-resume-and-artifact-state.md
@@ -18,7 +18,10 @@ state in an editable hidden blob.
 2. Invalidation is never-reviewed, directly changed, semantic-group mate, one-hop Python
    import, or a guarded `flagged_files` proposal. Broadcast files (pyproject, lockfiles,
    `conftest.py`) do not fan out. Queue order under a cap: never-reviewed → directly
-   changed → model-flagged → group/import-invalidated.
+   changed → model-flagged → group/import-invalidated. Same-hash inheritance is
+   content-addressed: any eligible file whose current hash already has a reviewed
+   representative is covered. Unserved group/import pending pairs and model flags
+   persist until that path is covered this round (including inherited coverage).
 3. Flag/env caps enforce on every cost basis. YAML enforces on `billed` and `estimated`,
    and is advisory on `unpriceable`. Overlay `uncapped` lifts the ceiling; overlay `0`
    is rejected as ambiguous.

--- a/docs/adr/0007-review-resume-and-artifact-state.md
+++ b/docs/adr/0007-review-resume-and-artifact-state.md
@@ -1,0 +1,42 @@
+# ADR-0007: File-level review resume and artifact-backed review state
+
+## Status
+
+Accepted
+
+## Context
+
+`lintro review --pr` re-reviewed the full base..head diff on every push. Chunk ordering
+is deterministic, so under a cost cap every round spent its budget on the same leading
+chunks. Partial reviews could render clean. The sticky comment stored authoritative
+state in an editable hidden blob.
+
+## Decision
+
+1. Coverage identity is `(path, normalized patch hash)`. `reviewed_sha` is metadata. The
+   hash covers only `+`/`-` lines.
+2. Invalidation is never-reviewed, directly changed, semantic-group mate, one-hop Python
+   import, or a guarded `flagged_files` proposal. Broadcast files (pyproject, lockfiles,
+   `conftest.py`) do not fan out. Queue order under a cap: never-reviewed → directly
+   changed → model-flagged → group/import-invalidated.
+3. Flag/env caps enforce on every cost basis. YAML enforces on `billed` and `estimated`,
+   and is advisory on `unpriceable`. Overlay `uncapped` lifts the ceiling; overlay `0`
+   is rejected as ambiguous.
+4. Coverage-at-HEAD below 100% of review-eligible files forces `INCOMPLETE`. READY
+   requires full coverage and no blocking findings. `lintro review` exit codes stay
+   0/1/2; the CI classifier reddens INCOMPLETE.
+5. Authoritative CI state lives in workflow artifacts. The sticky is pure rendering.
+   Local runs use `.lintro-cache/ai/review-state/` with no local↔CI sync. Missing or
+   untrusted state fails toward more review.
+
+## Consequences
+
+Capped reviews converge across rounds. A quiet re-review makes zero provider calls. A
+partial review cannot render clean or pass the AI Review check. Large capped API-key PRs
+are red on round 1 by design.
+
+`conftest.py` is a known semantic hole (test-wide fixtures) left on the revisit list.
+
+## References
+
+Epic #2156; #2154; #2157; ADR-0006.

--- a/docs/adr/0007-review-resume-and-artifact-state.md
+++ b/docs/adr/0007-review-resume-and-artifact-state.md
@@ -21,9 +21,9 @@ state in an editable hidden blob.
    changed → model-flagged → group/import-invalidated. Same-hash inheritance is
    content-addressed: any eligible file whose current hash already has a reviewed
    representative is covered. Unserved group/import pending pairs and model flags
-   persist until that path is covered this round (including inherited coverage).
-   The same ``(path, hash)`` may be flagged only once; a repeat flag cannot
-   re-queue that unchanged file.
+   persist until that path is covered this round (including inherited coverage). The
+   same `(path, hash)` may be flagged only once; a repeat flag cannot re-queue that
+   unchanged file.
 3. Flag/env caps enforce on every cost basis. YAML enforces on `billed` and `estimated`,
    and is advisory on `unpriceable`. Overlay `uncapped` lifts the ceiling; overlay `0`
    is rejected as ambiguous.

--- a/docs/adr/0007-review-resume-and-artifact-state.md
+++ b/docs/adr/0007-review-resume-and-artifact-state.md
@@ -22,6 +22,8 @@ state in an editable hidden blob.
    content-addressed: any eligible file whose current hash already has a reviewed
    representative is covered. Unserved group/import pending pairs and model flags
    persist until that path is covered this round (including inherited coverage).
+   The same ``(path, hash)`` may be flagged only once; a repeat flag cannot
+   re-queue that unchanged file.
 3. Flag/env caps enforce on every cost basis. YAML enforces on `billed` and `estimated`,
    and is advisory on `unpriceable`. Overlay `uncapped` lifts the ceiling; overlay `0`
    is rejected as ambiguous.

--- a/docs/ai-review-report.md
+++ b/docs/ai-review-report.md
@@ -1,0 +1,33 @@
+# How to read a Lintro review report
+
+The sticky PR comment is an index. Finding detail lives on inline comments.
+Authoritative coverage state lives in workflow artifacts, not in the comment.
+
+## Verdict
+
+The title carries the derived verdict:
+
+- **Blocked** — at least one open P1
+- **Changes requested** — open P2, no P1
+- **Nits only** — only open P3
+- **Ready** — no open findings **and** every review-eligible file is covered at HEAD
+- **Incomplete** — coverage-at-HEAD is below 100%. The findings-based label is withheld
+  so a partial round can never look clean.
+
+`~` on cost or tokens means the figure was estimated locally (subscription CLI, or a
+provider that returned no usage counters). Subscription runs still show “what this would
+have cost”; that figure is not a bill.
+
+## Coverage and resume
+
+A file is covered when its current normalized patch hash matches a stored entry.
+Content-identical rebases keep coverage. The next round reviews never-reviewed files
+first, then directly changed, then model-flagged, then group/import-invalidated files.
+
+`--full` discards carried coverage for one run. `--max-cost-usd uncapped` lifts a
+flag/env cap. Overlay `0` is rejected; use `uncapped` or a positive value.
+
+## Update in place
+
+The primary sticky updates in place. When history would overflow GitHub’s comment cap,
+an archive sticky is created and the primary keeps heading, aggregates, and a link.

--- a/docs/architecture/AI-REVIEW-EXECUTION.md
+++ b/docs/architecture/AI-REVIEW-EXECUTION.md
@@ -63,3 +63,14 @@ Phase 1 locks the gaps listed in ADR-0006:
 - `tests/unit/ai/review/test_architecture_characterization_1972.py` — gap coverage:
   config-resolution idempotence, shared `run_review` kwargs, error-contract body parity,
   MCP error mapping.
+
+## File-level resume (#2154 / ADR-0007)
+
+Coverage is keyed `(path, normalized patch hash)` and stored in workflow artifacts (CI)
+or `.lintro-cache/ai/review-state/` (local). A quiet re-review of an already-covered
+HEAD makes zero provider calls. Partial coverage forces `ReviewVerdict.INCOMPLETE`;
+`lintro review` still exits 0/1 from findings, and `classify_review_outcome.py` reddens
+the check.
+
+See [ADR-0007](../adr/0007-review-resume-and-artifact-state.md) and
+[ai-review-report.md](../ai-review-report.md).

--- a/lintro/ai/cli_schemas.py
+++ b/lintro/ai/cli_schemas.py
@@ -169,6 +169,18 @@ REVIEW_CLI_SCHEMA: dict[str, object] = {
                 },
             },
         },
+        "flagged_files": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": ["path", "reason"],
+                "additionalProperties": False,
+                "properties": {
+                    "path": {"type": "string"},
+                    "reason": {"type": "string"},
+                },
+            },
+        },
     },
 }
 

--- a/lintro/ai/config_overrides.py
+++ b/lintro/ai/config_overrides.py
@@ -63,7 +63,9 @@ _ENV_BY_FIELD: dict[str, str] = {
 _ENABLED_TRUE = frozenset({"1", "true"})
 _ENABLED_FALSE = frozenset({"0", "false"})
 _ENABLED_ACCEPTED = "1, 0, true, false"
-_MAX_COST_ACCEPTED = "a positive number (USD cap), or 0 for uncapped"
+_MAX_COST_ACCEPTED = "a positive number (USD cap), or uncapped"
+_UNCAP_SENTINEL = "uncapped"
+_ZERO_OVERLAY_ERROR = "ambiguous — use 'uncapped' or a positive value"
 
 _FLAG_BY_FIELD: dict[str, str] = {
     "provider": "--provider",
@@ -152,12 +154,11 @@ def apply_cli_overrides(
     """Apply ``lintro review`` CLI flags on top of a resolved config.
 
     Flags beat env vars. Omitted flags leave the corresponding field
-    untouched. There is no ``--enabled`` flag. Literal ``0`` for
-    ``--max-cost-usd`` means uncapped (mapped to ``None`` before overlay
-    so Pydantic cannot treat it as a $0 cap). Overlaying ``max_cost_usd``
-    also stamps both transport-profile cost fields so
-    ``apply_resolved_transport`` cannot clobber flag/env with a YAML
-    profile cap (#2024).
+    untouched. There is no ``--enabled`` flag. ``uncapped`` (any case)
+    lifts the ceiling. Overlay ``0`` is rejected as ambiguous (#2154).
+    Overlaying ``max_cost_usd`` also stamps both transport-profile cost
+    fields so ``apply_resolved_transport`` cannot clobber flag/env with a
+    YAML profile cap (#2024).
 
     Args:
         resolved: Config + provenance after the env layer.
@@ -239,10 +240,9 @@ def _parse_bool_override(raw: str, *, name: str) -> bool:
 def _parse_max_cost_usd(raw: object, *, name: str) -> float | None:
     """Parse a cost-cap override into a USD ceiling, or None if uncapped.
 
-    Literal ``0`` (including ``0.0``) means unlimited, matching
-    :class:`~lintro.ai.budget.CostBudget`. This mapping happens *before*
-    overlay: Pydantic ``max_cost_usd: float | None`` with ``ge=0`` would
-    otherwise accept ``0.0`` as a zero-dollar cap (#2024).
+    ``uncapped`` (case-insensitive) lifts the ceiling. Overlay ``0`` is
+    rejected — it was the #2024 spelling for uncapped and is now
+    ambiguous against a literal $0 YAML cap (#2154).
 
     Args:
         raw: Env-var string or CLI float.
@@ -252,10 +252,12 @@ def _parse_max_cost_usd(raw: object, *, name: str) -> float | None:
         A positive finite float, or None when the cap is lifted.
 
     Raises:
-        AIConfigOverrideError: If *raw* is negative, non-numeric, or
-            non-finite.
+        AIConfigOverrideError: If *raw* is ``0``, negative, non-numeric,
+            or non-finite.
     """
     text = str(raw).strip()
+    if text.lower() == _UNCAP_SENTINEL:
+        return None
     try:
         value = float(text)
     except ValueError:
@@ -267,7 +269,9 @@ def _parse_max_cost_usd(raw: object, *, name: str) -> float | None:
             f"{name}={raw!r} is not one of: {_MAX_COST_ACCEPTED}",
         )
     if value == 0:
-        return None
+        raise AIConfigOverrideError(
+            f"{name}={raw!r} is {_ZERO_OVERLAY_ERROR}",
+        )
     return value
 
 

--- a/lintro/ai/prompts/templates/review/output_schema.json
+++ b/lintro/ai/prompts/templates/review/output_schema.json
@@ -48,5 +48,11 @@
       "confidence": "high|medium|low",
       "checklist_ids": [1, 2]
     }
+  ],
+  "flagged_files": [
+    {
+      "path": "path/to/already-reviewed-file.py",
+      "reason": "Why this covered file should be re-read next round"
+    }
   ]
 }

--- a/lintro/ai/review/cost_cap.py
+++ b/lintro/ai/review/cost_cap.py
@@ -1,0 +1,33 @@
+"""ConfigSource × cost_basis enforcement for ``max_cost_usd`` (#2154).
+
+Flag and env overlays are operator intent for this run and enforce on
+every cost basis, including subscription CLI. Committed YAML is repo
+policy and is transport-unaware: it enforces when real money is at
+stake (``billed`` or ``estimated``) and is display-only on
+``unpriceable``. Unset stays uncapped. Shadow pricing (``~$``) is
+unchanged — measurement is not enforcement.
+"""
+
+from __future__ import annotations
+
+from lintro.ai.enums.config_source import ConfigSource
+from lintro.ai.enums.cost_basis import CostBasis
+
+__all__ = ["cap_is_enforced"]
+
+
+def cap_is_enforced(*, source: ConfigSource, basis: CostBasis) -> bool:
+    """Return whether a resolved dollar cap must stop the run.
+
+    Args:
+        source: Where ``max_cost_usd`` was set.
+        basis: How the run's spend is measured.
+
+    Returns:
+        True when the orchestrator must treat the cap as a hard stop.
+    """
+    if source in (ConfigSource.FLAG, ConfigSource.ENV):
+        return True
+    if source is ConfigSource.CONFIG:
+        return basis in (CostBasis.BILLED, CostBasis.ESTIMATED)
+    return False

--- a/lintro/ai/review/coverage.py
+++ b/lintro/ai/review/coverage.py
@@ -28,6 +28,7 @@ __all__ = [
     "inherit_same_round_paths",
     "latest_coverage_by_path",
     "carry_unserved_flags",
+    "consume_served_flags",
     "pending_invalidations_for",
     "queue_paths",
     "review_eligible_paths",
@@ -119,6 +120,7 @@ def classify_files(
     import_importers: Mapping[str, set[str]] | None = None,
     flags: Sequence[FlaggedFile] = (),
     pending_invalidations: Sequence[tuple[str, str]] = (),
+    consumed_flags: Sequence[tuple[str, str]] = (),
     force_full: bool = False,
 ) -> tuple[ClassifiedFile, ...]:
     """Classify each eligible file for this resume round.
@@ -132,6 +134,7 @@ def classify_files(
         flags: Guarded reviewer flags from prior rounds.
         pending_invalidations: Unserved group/import pairs from a prior
             capped round.
+        consumed_flags: ``(path, hash)`` pairs already honored once.
         force_full: When True, treat every file as never-reviewed.
 
     Returns:
@@ -185,6 +188,7 @@ def classify_files(
         eligible_paths=set(eligible_paths),
         current_hashes=current_hashes,
         covered_hashes=covered_hashes,
+        consumed_flags=consumed_flags,
     )
 
     classified: list[ClassifiedFile] = []
@@ -347,6 +351,39 @@ def carry_unserved_flags(
     return (*new, *unserved)
 
 
+def consume_served_flags(
+    *,
+    prior_consumed: Sequence[tuple[str, str]],
+    flags: Sequence[FlaggedFile],
+    covered_now: Iterable[str],
+    current_hashes: Mapping[str, str],
+) -> tuple[tuple[str, str], ...]:
+    """Remember ``(path, hash)`` pairs whose flag was honored this round.
+
+    The same file+hash may be flagged only once (#2154). After the
+    provider reads that path (or a same-hash sibling covers it), a
+    repeat flag cannot re-queue it.
+
+    Args:
+        prior_consumed: Honored pairs from previous rounds.
+        flags: Prior and newly emitted flags considered this round.
+        covered_now: Paths covered this round, including inheritance.
+        current_hashes: Current normalized patch hash per path.
+
+    Returns:
+        Deduplicated honored pairs, prior first.
+    """
+    consumed = dict.fromkeys(prior_consumed)
+    covered = set(covered_now)
+    for flag in flags:
+        if flag.path not in covered:
+            continue
+        patch_hash = flag.patch_hash or current_hashes.get(flag.path, "")
+        if patch_hash:
+            consumed[(flag.path, patch_hash)] = None
+    return tuple(consumed)
+
+
 def pending_invalidations_for(
     *,
     classified: Sequence[ClassifiedFile],
@@ -495,10 +532,12 @@ def _allowed_flags(
     eligible_paths: set[str],
     current_hashes: Mapping[str, str],
     covered_hashes: set[tuple[str, str]],
+    consumed_flags: Sequence[tuple[str, str]] = (),
 ) -> dict[str, str]:
     """Allowlist, one-way, cap, and de-dupe reviewer flags."""
     accepted: dict[str, str] = {}
     seen_keys: set[tuple[str, str]] = set()
+    consumed = set(consumed_flags)
     for flag in flags:
         if len(accepted) >= MAX_FLAGS_PER_ROUND:
             break
@@ -507,7 +546,7 @@ def _allowed_flags(
         current = current_hashes.get(flag.path, "")
         patch_hash = flag.patch_hash or current
         key = (flag.path, patch_hash)
-        if key in seen_keys:
+        if key in seen_keys or key in consumed:
             continue
         seen_keys.add(key)
         # One-way: only a covered (path, hash) can be pushed back.

--- a/lintro/ai/review/coverage.py
+++ b/lintro/ai/review/coverage.py
@@ -27,6 +27,7 @@ __all__ = [
     "directly_changed_paths",
     "inherit_same_round_paths",
     "latest_coverage_by_path",
+    "carry_unserved_flags",
     "pending_invalidations_for",
     "queue_paths",
     "review_eligible_paths",
@@ -313,6 +314,39 @@ def directly_changed_paths(
     return changed
 
 
+def carry_unserved_flags(
+    *,
+    new_flags: Sequence[FlaggedFile],
+    prior_flags: Sequence[FlaggedFile],
+    covered_now: Iterable[str],
+) -> tuple[FlaggedFile, ...]:
+    """Keep prior model flags whose path was not covered this round.
+
+    A capped round can leave a ``MODEL_FLAGGED`` path unserved. Those
+    flags must persist; otherwise the next classify treats the path as
+    ``COVERED`` and the request disappears.
+
+    Args:
+        new_flags: Flags produced by this round's completed chunks.
+        prior_flags: Flags carried from the previous trusted state.
+        covered_now: Paths covered this round, including same-hash
+            inheritance.
+
+    Returns:
+        This round's flags plus unserved prior flags, de-duplicated by
+        path with new flags winning.
+    """
+    covered = set(covered_now)
+    new = tuple(new_flags)
+    new_paths = {flag.path for flag in new}
+    unserved = tuple(
+        flag
+        for flag in prior_flags
+        if flag.path not in covered and flag.path not in new_paths
+    )
+    return (*new, *unserved)
+
+
 def pending_invalidations_for(
     *,
     classified: Sequence[ClassifiedFile],
@@ -322,10 +356,11 @@ def pending_invalidations_for(
 
     Args:
         classified: This round's classification.
-        reviewed_now: Paths the provider actually read (not inherited).
+        reviewed_now: Paths covered this round, including same-hash
+            siblings of a provider-read representative.
 
     Returns:
-        ``(path, need)`` pairs still awaiting a real review.
+        ``(path, need)`` pairs still awaiting coverage.
     """
     reviewed = set(reviewed_now)
     return tuple(

--- a/lintro/ai/review/coverage.py
+++ b/lintro/ai/review/coverage.py
@@ -1,0 +1,369 @@
+"""File-level coverage classification and queueing (#2154)."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass
+
+from lintro.ai.review.enums.changed_file_status import ChangedFileStatus
+from lintro.ai.review.enums.file_review_need import (
+    FILE_REVIEW_NEED_PRIORITY,
+    FileReviewNeed,
+)
+from lintro.ai.review.enums.file_skip_reason import FileSkipReason
+from lintro.ai.review.models.changed_file import ChangedFile
+from lintro.ai.review.models.coverage_counts import CoverageCounts
+from lintro.ai.review.models.coverage_record import CoverageRecord
+from lintro.ai.review.models.flagged_file import FlaggedFile
+from lintro.ai.review.models.skipped_file import SkippedFile
+from lintro.ai.review.patch_hash import normalized_patch_hash
+
+__all__ = [
+    "BROADCAST_FILENAMES",
+    "MAX_FLAGS_PER_ROUND",
+    "ClassifiedFile",
+    "classify_files",
+    "coverage_counts",
+    "queue_paths",
+    "review_eligible_paths",
+]
+
+#: Paths that never fan out invalidation (ADR-0007). ``conftest.py`` is a
+#: known semantic hole: test-wide fixtures can change behavior without
+#: re-entering dependents. Covered by groups and model flags; revisit list.
+BROADCAST_FILENAMES = frozenset(
+    {
+        "pyproject.toml",
+        "poetry.lock",
+        "uv.lock",
+        "Pipfile.lock",
+        "package-lock.json",
+        "pnpm-lock.yaml",
+        "yarn.lock",
+        "Cargo.lock",
+        "conftest.py",
+    },
+)
+
+MAX_FLAGS_PER_ROUND = 8
+
+
+@dataclass(frozen=True, slots=True)
+class ClassifiedFile:
+    """A review-eligible file and why it is (or is not) queued.
+
+    Attributes:
+        path: Repository-relative path.
+        patch_hash: Current normalized patch hash.
+        need: Classification for this round.
+        flag_reason: Reviewer reason when ``need`` is model-flagged.
+    """
+
+    path: str
+    patch_hash: str
+    need: FileReviewNeed
+    flag_reason: str = ""
+
+
+def review_eligible_paths(
+    *,
+    changed_files: Sequence[ChangedFile],
+    skipped: Sequence[SkippedFile] = (),
+) -> tuple[str, ...]:
+    """Return paths that count toward 100% coverage.
+
+    Deletions leave the denominator (their findings resolve as a delete).
+    Path/config/agent-scope skips never make completion impossible.
+    Repetitive-diff samples stay eligible so an identical-hash sibling
+    can inherit coverage.
+
+    Args:
+        changed_files: Files in the current diff.
+        skipped: Files dropped by selection or chunking.
+
+    Returns:
+        Sorted eligible paths.
+    """
+    skip_reasons = {entry.path: entry.reason for entry in skipped}
+    eligible: list[str] = []
+    for changed in changed_files:
+        status = (
+            changed.status
+            if isinstance(changed.status, ChangedFileStatus)
+            else ChangedFileStatus(str(changed.status))
+        )
+        if status is ChangedFileStatus.DELETED:
+            continue
+        reason = skip_reasons.get(changed.path)
+        if reason in {
+            FileSkipReason.PATH_FILTER,
+            FileSkipReason.CONFIG_EXCLUDED,
+            FileSkipReason.AGENT_SCOPE,
+        }:
+            continue
+        eligible.append(changed.path)
+    return tuple(sorted(set(eligible)))
+
+
+def classify_files(
+    *,
+    eligible_paths: Sequence[str],
+    current_hashes: Mapping[str, str],
+    coverage: Sequence[CoverageRecord],
+    groups: Sequence[Sequence[str]] = (),
+    import_importers: Mapping[str, set[str]] | None = None,
+    flags: Sequence[FlaggedFile] = (),
+    force_full: bool = False,
+) -> tuple[ClassifiedFile, ...]:
+    """Classify each eligible file for this resume round.
+
+    Args:
+        eligible_paths: Review-eligible paths at HEAD.
+        current_hashes: Current normalized patch hash per path.
+        coverage: Prior coverage records (possibly empty).
+        groups: Semantic groups (each a sequence of paths).
+        import_importers: ``{directly_changed: {importer, ...}}``.
+        flags: Guarded reviewer flags from prior rounds.
+        force_full: When True, treat every file as never-reviewed.
+
+    Returns:
+        One classification per eligible path, in path order.
+    """
+    by_path = _latest_by_path(coverage)
+    covered_hashes = {(record.path, record.patch_hash) for record in coverage}
+    if force_full:
+        return tuple(
+            ClassifiedFile(
+                path=path,
+                patch_hash=current_hashes.get(path, ""),
+                need=FileReviewNeed.NEVER_REVIEWED,
+            )
+            for path in eligible_paths
+        )
+
+    directly_changed: set[str] = set()
+    never_reviewed: set[str] = set()
+    for path in eligible_paths:
+        current = current_hashes.get(path, "")
+        prior = by_path.get(path)
+        if prior is None:
+            never_reviewed.add(path)
+        elif prior.patch_hash != current:
+            directly_changed.add(path)
+
+    sampled_covered = _inherit_sampled_hashes(
+        eligible_paths=eligible_paths,
+        current_hashes=current_hashes,
+        covered_hashes=covered_hashes,
+    )
+
+    group_invalidated = _group_invalidated(
+        eligible_paths=eligible_paths,
+        groups=groups,
+        directly_changed=directly_changed,
+        broadcast=_broadcast_paths(eligible_paths),
+    )
+    import_invalidated: set[str] = set()
+    for importers in (import_importers or {}).values():
+        import_invalidated.update(importers)
+
+    allowed_flags = _allowed_flags(
+        flags=flags,
+        eligible_paths=set(eligible_paths),
+        current_hashes=current_hashes,
+        covered_hashes=covered_hashes,
+    )
+
+    classified: list[ClassifiedFile] = []
+    for path in eligible_paths:
+        current = current_hashes.get(path, "")
+        if path in never_reviewed and path not in sampled_covered:
+            need = FileReviewNeed.NEVER_REVIEWED
+            reason = ""
+        elif path in directly_changed:
+            need = FileReviewNeed.DIRECTLY_CHANGED
+            reason = ""
+        elif path in allowed_flags:
+            need = FileReviewNeed.MODEL_FLAGGED
+            reason = allowed_flags[path]
+        elif path in group_invalidated:
+            need = FileReviewNeed.GROUP_INVALIDATED
+            reason = ""
+        elif path in import_invalidated:
+            need = FileReviewNeed.IMPORT_INVALIDATED
+            reason = ""
+        else:
+            need = FileReviewNeed.COVERED
+            reason = ""
+        classified.append(
+            ClassifiedFile(
+                path=path,
+                patch_hash=current,
+                need=need,
+                flag_reason=reason,
+            ),
+        )
+    return tuple(classified)
+
+
+def queue_paths(*, classified: Sequence[ClassifiedFile]) -> tuple[str, ...]:
+    """Return files that need review, in cap-safe queue order.
+
+    Args:
+        classified: Output of :func:`classify_files`.
+
+    Returns:
+        Paths excluding ``COVERED``, sorted by priority then path.
+    """
+    pending = [item for item in classified if item.need is not FileReviewNeed.COVERED]
+    pending.sort(
+        key=lambda item: (
+            FILE_REVIEW_NEED_PRIORITY[item.need],
+            item.path,
+        ),
+    )
+    return tuple(item.path for item in pending)
+
+
+def coverage_counts(
+    *,
+    classified: Sequence[ClassifiedFile],
+    reviewed_now: Iterable[str],
+) -> CoverageCounts:
+    """Build per-round coverage counters.
+
+    Args:
+        classified: This round's classification.
+        reviewed_now: Paths the provider actually read.
+
+    Returns:
+        Counters for the JSON envelope and sticky Variant B.
+    """
+    reviewed_set = set(reviewed_now)
+    reviewed = 0
+    carried = 0
+    awaiting = 0
+    invalidated = 0
+    for item in classified:
+        if item.need is FileReviewNeed.COVERED:
+            carried += 1
+            continue
+        if item.path in reviewed_set:
+            reviewed += 1
+            if item.need in {
+                FileReviewNeed.GROUP_INVALIDATED,
+                FileReviewNeed.IMPORT_INVALIDATED,
+                FileReviewNeed.MODEL_FLAGGED,
+            }:
+                invalidated += 1
+            continue
+        awaiting += 1
+        if item.need in {
+            FileReviewNeed.GROUP_INVALIDATED,
+            FileReviewNeed.IMPORT_INVALIDATED,
+            FileReviewNeed.MODEL_FLAGGED,
+        }:
+            invalidated += 1
+    return CoverageCounts(
+        reviewed=reviewed,
+        carried=carried,
+        awaiting=awaiting,
+        invalidated=invalidated,
+        eligible=len(classified),
+    )
+
+
+def hashes_for_diffs(*, diffs: Mapping[str, str]) -> dict[str, str]:
+    """Hash each per-file unified diff.
+
+    Args:
+        diffs: Path to unified diff text.
+
+    Returns:
+        Path to normalized patch hash.
+    """
+    return {path: normalized_patch_hash(text) for path, text in diffs.items()}
+
+
+def _latest_by_path(
+    coverage: Sequence[CoverageRecord],
+) -> dict[str, CoverageRecord]:
+    """Keep the highest-round record per path."""
+    latest: dict[str, CoverageRecord] = {}
+    for record in coverage:
+        current = latest.get(record.path)
+        if current is None or record.round >= current.round:
+            latest[record.path] = record
+    return latest
+
+
+def _inherit_sampled_hashes(
+    *,
+    eligible_paths: Sequence[str],
+    current_hashes: Mapping[str, str],
+    covered_hashes: set[tuple[str, str]],
+) -> set[str]:
+    """Mark files whose hash already has a reviewed representative."""
+    reviewed_hashes = {patch_hash for _, patch_hash in covered_hashes}
+    inherited: set[str] = set()
+    covered_paths = {path for path, _ in covered_hashes}
+    for path in eligible_paths:
+        if path in covered_paths:
+            continue
+        patch_hash = current_hashes.get(path, "")
+        if patch_hash and patch_hash in reviewed_hashes:
+            inherited.add(path)
+    return inherited
+
+
+def _group_invalidated(
+    *,
+    eligible_paths: Sequence[str],
+    groups: Sequence[Sequence[str]],
+    directly_changed: set[str],
+    broadcast: set[str],
+) -> set[str]:
+    """Return covered group-mates of a non-broadcast changed file."""
+    if not directly_changed:
+        return set()
+    changed_triggers = directly_changed - broadcast
+    invalidated: set[str] = set()
+    eligible = set(eligible_paths)
+    for group in groups:
+        members = set(group) & eligible
+        if members & changed_triggers:
+            invalidated.update(members - directly_changed)
+    return invalidated
+
+
+def _broadcast_paths(paths: Sequence[str]) -> set[str]:
+    """Return members whose basename is a broadcast filename."""
+    return {path for path in paths if path.rsplit("/", 1)[-1] in BROADCAST_FILENAMES}
+
+
+def _allowed_flags(
+    *,
+    flags: Sequence[FlaggedFile],
+    eligible_paths: set[str],
+    current_hashes: Mapping[str, str],
+    covered_hashes: set[tuple[str, str]],
+) -> dict[str, str]:
+    """Allowlist, one-way, cap, and de-dupe reviewer flags."""
+    accepted: dict[str, str] = {}
+    seen_keys: set[tuple[str, str]] = set()
+    for flag in flags:
+        if len(accepted) >= MAX_FLAGS_PER_ROUND:
+            break
+        if flag.path not in eligible_paths:
+            continue
+        current = current_hashes.get(flag.path, "")
+        patch_hash = flag.patch_hash or current
+        key = (flag.path, patch_hash)
+        if key in seen_keys:
+            continue
+        seen_keys.add(key)
+        # One-way: only a covered (path, hash) can be pushed back.
+        if (flag.path, current) not in covered_hashes:
+            continue
+        accepted[flag.path] = flag.reason
+    return accepted

--- a/lintro/ai/review/coverage.py
+++ b/lintro/ai/review/coverage.py
@@ -27,6 +27,7 @@ __all__ = [
     "directly_changed_paths",
     "inherit_same_round_paths",
     "latest_coverage_by_path",
+    "pending_invalidations_for",
     "queue_paths",
     "review_eligible_paths",
 ]
@@ -116,6 +117,7 @@ def classify_files(
     groups: Sequence[Sequence[str]] = (),
     import_importers: Mapping[str, set[str]] | None = None,
     flags: Sequence[FlaggedFile] = (),
+    pending_invalidations: Sequence[tuple[str, str]] = (),
     force_full: bool = False,
 ) -> tuple[ClassifiedFile, ...]:
     """Classify each eligible file for this resume round.
@@ -127,6 +129,8 @@ def classify_files(
         groups: Semantic groups (each a sequence of paths).
         import_importers: ``{directly_changed: {importer, ...}}``.
         flags: Guarded reviewer flags from prior rounds.
+        pending_invalidations: Unserved group/import pairs from a prior
+            capped round.
         force_full: When True, treat every file as never-reviewed.
 
     Returns:
@@ -167,24 +171,13 @@ def classify_files(
         directly_changed=directly_changed,
         broadcast=broadcast,
     )
-    group_invalidated.update(
-        _stale_group_invalidated(
-            eligible_paths=eligible_paths,
-            groups=groups,
-            by_path=by_path,
-            broadcast=broadcast,
-        ),
-    )
+    pending_group, pending_import = _pending_sets(pending_invalidations)
+    group_invalidated.update(pending_group)
     graph = import_importers or {}
     import_invalidated: set[str] = set()
     for imported in directly_changed:
         import_invalidated.update(graph.get(imported, set()))
-    import_invalidated.update(
-        _stale_import_invalidated(
-            import_importers=graph,
-            by_path=by_path,
-        ),
-    )
+    import_invalidated.update(pending_import)
 
     allowed_flags = _allowed_flags(
         flags=flags,
@@ -320,6 +313,33 @@ def directly_changed_paths(
     return changed
 
 
+def pending_invalidations_for(
+    *,
+    classified: Sequence[ClassifiedFile],
+    reviewed_now: Iterable[str],
+) -> tuple[tuple[str, str], ...]:
+    """Return unserved group/import pairs to persist for the next round.
+
+    Args:
+        classified: This round's classification.
+        reviewed_now: Paths the provider actually read (not inherited).
+
+    Returns:
+        ``(path, need)`` pairs still awaiting a real review.
+    """
+    reviewed = set(reviewed_now)
+    return tuple(
+        (item.path, item.need.value)
+        for item in classified
+        if item.need
+        in {
+            FileReviewNeed.GROUP_INVALIDATED,
+            FileReviewNeed.IMPORT_INVALIDATED,
+        }
+        and item.path not in reviewed
+    )
+
+
 def inherit_same_round_paths(
     *,
     reviewed_now: Sequence[str],
@@ -415,56 +435,18 @@ def _group_invalidated(
     return invalidated
 
 
-def _stale_group_invalidated(
-    *,
-    eligible_paths: Sequence[str],
-    groups: Sequence[Sequence[str]],
-    by_path: Mapping[str, CoverageRecord],
-    broadcast: set[str],
-) -> set[str]:
-    """Re-queue group-mates a later capped round reviewed after they were.
-
-    Invalidation is derived from stored rounds so an unserved mate stays
-    awaiting after the changed file is covered and the next push is empty.
-    Broadcast files never contribute a trigger round.
-    """
-    if not groups:
-        return set()
-    eligible = set(eligible_paths)
-    invalidated: set[str] = set()
-    for group in groups:
-        members = set(group) & eligible
-        trigger_rounds = [
-            by_path[path].round
-            for path in members
-            if path not in broadcast and path in by_path
-        ]
-        if not trigger_rounds:
-            continue
-        newest = max(trigger_rounds)
-        for path in members:
-            prior = by_path.get(path)
-            if prior is not None and prior.round < newest:
-                invalidated.add(path)
-    return invalidated
-
-
-def _stale_import_invalidated(
-    *,
-    import_importers: Mapping[str, set[str]],
-    by_path: Mapping[str, CoverageRecord],
-) -> set[str]:
-    """Re-queue importers of a dependency reviewed in a later round."""
-    invalidated: set[str] = set()
-    for imported, importers in import_importers.items():
-        imported_rec = by_path.get(imported)
-        if imported_rec is None:
-            continue
-        for importer in importers:
-            importer_rec = by_path.get(importer)
-            if importer_rec is not None and importer_rec.round < imported_rec.round:
-                invalidated.add(importer)
-    return invalidated
+def _pending_sets(
+    pending_invalidations: Sequence[tuple[str, str]],
+) -> tuple[set[str], set[str]]:
+    """Split persisted pending pairs into group and import path sets."""
+    group: set[str] = set()
+    imports: set[str] = set()
+    for path, need in pending_invalidations:
+        if need == FileReviewNeed.GROUP_INVALIDATED:
+            group.add(path)
+        elif need == FileReviewNeed.IMPORT_INVALIDATED:
+            imports.add(path)
+    return group, imports
 
 
 def _broadcast_paths(paths: Sequence[str]) -> set[str]:

--- a/lintro/ai/review/coverage.py
+++ b/lintro/ai/review/coverage.py
@@ -24,6 +24,9 @@ __all__ = [
     "ClassifiedFile",
     "classify_files",
     "coverage_counts",
+    "directly_changed_paths",
+    "inherit_same_round_paths",
+    "latest_coverage_by_path",
     "queue_paths",
     "review_eligible_paths",
 ]
@@ -129,7 +132,7 @@ def classify_files(
     Returns:
         One classification per eligible path, in path order.
     """
-    by_path = _latest_by_path(coverage)
+    by_path = latest_coverage_by_path(coverage)
     covered_hashes = {(record.path, record.patch_hash) for record in coverage}
     if force_full:
         return tuple(
@@ -157,15 +160,31 @@ def classify_files(
         covered_hashes=covered_hashes,
     )
 
+    broadcast = _broadcast_paths(eligible_paths)
     group_invalidated = _group_invalidated(
         eligible_paths=eligible_paths,
         groups=groups,
         directly_changed=directly_changed,
-        broadcast=_broadcast_paths(eligible_paths),
+        broadcast=broadcast,
     )
+    group_invalidated.update(
+        _stale_group_invalidated(
+            eligible_paths=eligible_paths,
+            groups=groups,
+            by_path=by_path,
+            broadcast=broadcast,
+        ),
+    )
+    graph = import_importers or {}
     import_invalidated: set[str] = set()
-    for importers in (import_importers or {}).values():
-        import_invalidated.update(importers)
+    for imported in directly_changed:
+        import_invalidated.update(graph.get(imported, set()))
+    import_invalidated.update(
+        _stale_import_invalidated(
+            import_importers=graph,
+            by_path=by_path,
+        ),
+    )
 
     allowed_flags = _allowed_flags(
         flags=flags,
@@ -273,6 +292,78 @@ def coverage_counts(
     )
 
 
+def directly_changed_paths(
+    *,
+    eligible_paths: Sequence[str],
+    current_hashes: Mapping[str, str],
+    coverage: Sequence[CoverageRecord],
+) -> set[str]:
+    """Return paths whose latest stored hash differs from HEAD.
+
+    Uses the highest-round record per path so a later review of a new
+    hash does not keep treating the file as changed.
+
+    Args:
+        eligible_paths: Review-eligible paths at HEAD.
+        current_hashes: Current normalized patch hash per path.
+        coverage: Prior coverage records.
+
+    Returns:
+        Paths that are directly changed this round.
+    """
+    latest = latest_coverage_by_path(coverage)
+    changed: set[str] = set()
+    for path in eligible_paths:
+        prior = latest.get(path)
+        if prior is not None and prior.patch_hash != current_hashes.get(path, ""):
+            changed.add(path)
+    return changed
+
+
+def inherit_same_round_paths(
+    *,
+    reviewed_now: Sequence[str],
+    eligible_paths: Sequence[str],
+    current_hashes: Mapping[str, str],
+) -> tuple[str, ...]:
+    """Credit sampled siblings that share a reviewed representative's hash.
+
+    Args:
+        reviewed_now: Paths the provider actually read.
+        eligible_paths: Review-eligible paths at HEAD.
+        current_hashes: Current normalized patch hash per path.
+
+    Returns:
+        ``reviewed_now`` plus same-hash siblings, de-duplicated.
+    """
+    reviewed = list(dict.fromkeys(reviewed_now))
+    reviewed_hashes = {
+        current_hashes.get(path, "")
+        for path in reviewed
+        if current_hashes.get(path, "")
+    }
+    extras = [
+        path
+        for path in eligible_paths
+        if path not in reviewed
+        and current_hashes.get(path, "") in reviewed_hashes
+        and current_hashes.get(path, "")
+    ]
+    return (*reviewed, *extras)
+
+
+def latest_coverage_by_path(
+    coverage: Sequence[CoverageRecord],
+) -> dict[str, CoverageRecord]:
+    """Keep the highest-round record per path."""
+    latest: dict[str, CoverageRecord] = {}
+    for record in coverage:
+        current = latest.get(record.path)
+        if current is None or record.round >= current.round:
+            latest[record.path] = record
+    return latest
+
+
 def hashes_for_diffs(*, diffs: Mapping[str, str]) -> dict[str, str]:
     """Hash each per-file unified diff.
 
@@ -283,18 +374,6 @@ def hashes_for_diffs(*, diffs: Mapping[str, str]) -> dict[str, str]:
         Path to normalized patch hash.
     """
     return {path: normalized_patch_hash(text) for path, text in diffs.items()}
-
-
-def _latest_by_path(
-    coverage: Sequence[CoverageRecord],
-) -> dict[str, CoverageRecord]:
-    """Keep the highest-round record per path."""
-    latest: dict[str, CoverageRecord] = {}
-    for record in coverage:
-        current = latest.get(record.path)
-        if current is None or record.round >= current.round:
-            latest[record.path] = record
-    return latest
 
 
 def _inherit_sampled_hashes(
@@ -333,6 +412,58 @@ def _group_invalidated(
         members = set(group) & eligible
         if members & changed_triggers:
             invalidated.update(members - directly_changed)
+    return invalidated
+
+
+def _stale_group_invalidated(
+    *,
+    eligible_paths: Sequence[str],
+    groups: Sequence[Sequence[str]],
+    by_path: Mapping[str, CoverageRecord],
+    broadcast: set[str],
+) -> set[str]:
+    """Re-queue group-mates a later capped round reviewed after they were.
+
+    Invalidation is derived from stored rounds so an unserved mate stays
+    awaiting after the changed file is covered and the next push is empty.
+    Broadcast files never contribute a trigger round.
+    """
+    if not groups:
+        return set()
+    eligible = set(eligible_paths)
+    invalidated: set[str] = set()
+    for group in groups:
+        members = set(group) & eligible
+        trigger_rounds = [
+            by_path[path].round
+            for path in members
+            if path not in broadcast and path in by_path
+        ]
+        if not trigger_rounds:
+            continue
+        newest = max(trigger_rounds)
+        for path in members:
+            prior = by_path.get(path)
+            if prior is not None and prior.round < newest:
+                invalidated.add(path)
+    return invalidated
+
+
+def _stale_import_invalidated(
+    *,
+    import_importers: Mapping[str, set[str]],
+    by_path: Mapping[str, CoverageRecord],
+) -> set[str]:
+    """Re-queue importers of a dependency reviewed in a later round."""
+    invalidated: set[str] = set()
+    for imported, importers in import_importers.items():
+        imported_rec = by_path.get(imported)
+        if imported_rec is None:
+            continue
+        for importer in importers:
+            importer_rec = by_path.get(importer)
+            if importer_rec is not None and importer_rec.round < imported_rec.round:
+                invalidated.add(importer)
     return invalidated
 
 

--- a/lintro/ai/review/custom_agent_runner.py
+++ b/lintro/ai/review/custom_agent_runner.py
@@ -68,6 +68,7 @@ class CustomAgentPassResult:
         agent_name: Name of the agent that produced the pass.
         findings: Findings reported by the agent, already attributed via
             :attr:`~lintro.ai.review.models.review_finding.ReviewFinding.source`.
+        files: Changed files this pass actually reviewed.
         input_tokens: Prompt tokens consumed by the pass.
         output_tokens: Completion tokens produced by the pass.
         cost_estimate: Estimated USD cost of the pass.
@@ -75,6 +76,7 @@ class CustomAgentPassResult:
 
     agent_name: str
     findings: tuple[ReviewFinding, ...] = ()
+    files: tuple[str, ...] = ()
     input_tokens: int = 0
     output_tokens: int = 0
     cost_estimate: float = 0.0
@@ -326,6 +328,7 @@ async def run_custom_agent_passes(
                 agent=agent,
                 content=response.content,
             ),
+            files=entry.files,
             input_tokens=response.input_tokens,
             output_tokens=response.output_tokens,
             cost_estimate=response.cost_estimate,

--- a/lintro/ai/review/enums/file_review_need.py
+++ b/lintro/ai/review/enums/file_review_need.py
@@ -1,0 +1,43 @@
+"""Why a changed file is queued for review in a resume round (#2154)."""
+
+from __future__ import annotations
+
+from enum import StrEnum, auto
+
+__all__ = ["FILE_REVIEW_NEED_PRIORITY", "FileReviewNeed"]
+
+
+class FileReviewNeed(StrEnum):
+    """Classification of a review-eligible file for this round.
+
+    Queue order under a cap is never-reviewed → directly changed →
+    model-flagged → group/import-invalidated. Covered files are skipped
+    (zero provider calls) unless ``--full`` discards carried coverage.
+
+    Attributes:
+        NEVER_REVIEWED: No coverage entry for this path.
+        DIRECTLY_CHANGED: Stored hash differs from the current patch hash.
+        MODEL_FLAGGED: The reviewer asked for a re-read via ``flagged_files``.
+        GROUP_INVALIDATED: A semantic-group mate changed since this review.
+        IMPORT_INVALIDATED: A one-hop Python import dependency changed.
+        COVERED: Current hash matches a stored entry and nothing invalidated it.
+    """
+
+    NEVER_REVIEWED = auto()
+    DIRECTLY_CHANGED = auto()
+    MODEL_FLAGGED = auto()
+    GROUP_INVALIDATED = auto()
+    IMPORT_INVALIDATED = auto()
+    COVERED = auto()
+
+
+#: Numeric queue rank; lower runs first under a cost cap. Group and import
+#: share a rank so they interleave by path after the higher-priority buckets.
+FILE_REVIEW_NEED_PRIORITY: dict[FileReviewNeed, int] = {
+    FileReviewNeed.NEVER_REVIEWED: 0,
+    FileReviewNeed.DIRECTLY_CHANGED: 1,
+    FileReviewNeed.MODEL_FLAGGED: 2,
+    FileReviewNeed.GROUP_INVALIDATED: 3,
+    FileReviewNeed.IMPORT_INVALIDATED: 3,
+    FileReviewNeed.COVERED: 99,
+}

--- a/lintro/ai/review/enums/review_verdict.py
+++ b/lintro/ai/review/enums/review_verdict.py
@@ -15,10 +15,14 @@ class ReviewVerdict(StrEnum):
         BLOCKED: At least one open P1 finding.
         CHANGES_REQUESTED: No open P1 findings but at least one open P2.
         NITS_ONLY: Only open P3 findings remain.
-        READY: No open findings remain.
+        READY: No open findings remain and coverage-at-HEAD is complete.
+        INCOMPLETE: Coverage-at-HEAD is below 100% of review-eligible files.
+            Overrides the findings-based label so a partial round can never
+            render clean (#2154).
     """
 
     BLOCKED = auto()
     CHANGES_REQUESTED = auto()
     NITS_ONLY = auto()
     READY = auto()
+    INCOMPLETE = auto()

--- a/lintro/ai/review/finding_matcher.py
+++ b/lintro/ai/review/finding_matcher.py
@@ -321,6 +321,8 @@ def match_findings(
     findings: Sequence[ReviewFinding],
     round_number: int,
     head_sha: str = "",
+    reviewed_paths: frozenset[str] | None = None,
+    departed_paths: frozenset[str] | None = None,
 ) -> FindingMatchResult:
     """Match this round's findings against the previously persisted state.
 
@@ -340,6 +342,11 @@ def match_findings(
         round_number: Round number being recorded (1-based).
         head_sha: Head commit sha reviewed in this round; stamped onto findings
             resolved by this round.
+        reviewed_paths: Files re-reviewed this round. Open findings on other
+            paths carry forward. ``None`` keeps the legacy resolve-on-absence
+            behavior.
+        departed_paths: Paths that left the diff (deletes and rename sources)
+            and may resolve even when they were not re-reviewed.
 
     Returns:
         The per-round transitions plus the merged record set to persist.
@@ -404,6 +411,14 @@ def match_findings(
             continue
         if record.status is FindingStatus.RESOLVED:
             merged.append(record)
+            continue
+        path = record.file
+        left_diff = departed_paths is not None and path in departed_paths
+        unread = reviewed_paths is not None and path not in reviewed_paths
+        if unread and not left_diff:
+            merged.append(record)
+            carried.append(record)
+            outcomes[record.key] = FindingMatchOutcome.CARRIED
             continue
         closed = replace(
             record,

--- a/lintro/ai/review/finding_parser.py
+++ b/lintro/ai/review/finding_parser.py
@@ -12,6 +12,7 @@ from loguru import logger
 from lintro.ai.review.enums.evidence_style import EvidenceStyle
 from lintro.ai.review.enums.finding_kind import FindingKind
 from lintro.ai.review.models.finding_occurrence import parse_occurrences
+from lintro.ai.review.models.flagged_file import FlaggedFile
 from lintro.ai.review.models.review_finding import ReviewFinding, Severity
 from lintro.ai.review.models.suggested_change import parse_suggested_change
 from lintro.ai.review.narrative_parser import collapse_to_single_line
@@ -23,7 +24,9 @@ __all__ = [
     "normalize_finding_kind",
     "normalize_severity",
     "parse_findings",
+    "parse_flagged_files",
     "parse_severity_label",
+    "reject_context_findings",
 ]
 
 SEVERITY_SYNONYMS: dict[str, Severity] = {
@@ -227,3 +230,75 @@ def parse_findings(
         # it would silently override the agent's own front matter.
         return tuple(findings)
     return apply_p1_evidence_gate(findings=findings)
+
+
+def parse_flagged_files(*, raw_flags: object) -> tuple[FlaggedFile, ...]:
+    """Parse reviewer re-read requests from untrusted model JSON.
+
+    Args:
+        raw_flags: Raw ``flagged_files`` value from a parsed model response.
+
+    Returns:
+        Flags with a non-empty path and reason. Guards (allowlist, one-way,
+        cap) are applied later by the coverage classifier.
+    """
+    if not isinstance(raw_flags, list):
+        return ()
+    flags: list[FlaggedFile] = []
+    for item in raw_flags:
+        if not isinstance(item, dict):
+            continue
+        parsed = FlaggedFile.from_dict(item)
+        if parsed is not None:
+            flags.append(parsed)
+    return tuple(flags)
+
+
+def reject_context_findings(
+    *,
+    findings: tuple[ReviewFinding, ...],
+    allowed_paths: set[str],
+    eligible_paths: set[str],
+) -> tuple[tuple[ReviewFinding, ...], tuple[FlaggedFile, ...]]:
+    """Drop findings on read-only context files; convert others to flags.
+
+    Findings against files that needed review are kept. Findings against
+    other review-eligible paths become guarded flags. Everything else is
+    discarded so a prompt instruction is not the only boundary.
+
+    Args:
+        findings: Parsed findings from one chunk or the merged run.
+        allowed_paths: Paths this pass may emit findings against (the
+            resume queue, typically intersected with the chunk).
+        eligible_paths: Review-eligible paths in the current diff.
+
+    Returns:
+        Kept findings and flags converted from out-of-scope findings.
+    """
+    kept: list[ReviewFinding] = []
+    flags: list[FlaggedFile] = []
+    allowed = {_normalize_finding_path(path) for path in allowed_paths}
+    eligible = {_normalize_finding_path(path) for path in eligible_paths}
+    for finding in findings:
+        path = _normalize_finding_path(finding.file)
+        if path in allowed:
+            kept.append(finding)
+            continue
+        if path in eligible:
+            reason = finding.title.strip() or "re-read requested"
+            flags.append(FlaggedFile(path=path, reason=reason))
+            logger.info(
+                "Converted context-file finding on {path} to a flagged re-read",
+                path=path,
+            )
+            continue
+        logger.info(
+            "Rejected finding on non-review path {path}",
+            path=path or "(empty)",
+        )
+    return tuple(kept), tuple(flags)
+
+
+def _normalize_finding_path(path: str) -> str:
+    """Normalize a model-reported path for allowlist comparison."""
+    return path.strip().replace("\\", "/").removeprefix("./")

--- a/lintro/ai/review/github.py
+++ b/lintro/ai/review/github.py
@@ -30,6 +30,7 @@ from lintro.ai.review.finding_matcher import (
     normalize_file_path,
 )
 from lintro.ai.review.github_constants import (
+    ARCHIVE_MARKER,
     GITHUB_COMMENT_HARD_LIMIT,
     MAX_COMMENT_CHARS,
     STATE_MARKER_PREFIX,
@@ -55,7 +56,9 @@ from lintro.ai.review.github_sticky import (
     _cap_body as _cap_body,
 )
 from lintro.ai.review.github_sticky import (
+    build_sticky_bodies,
     build_sticky_comment,
+    matcher_reviewed_paths,
     parse_review_state,
     parse_review_state_v2,
 )
@@ -76,6 +79,7 @@ __all__ = [
     "GITHUB_COMMENT_HARD_LIMIT",
     "STATE_MARKER_PREFIX",
     "STICKY_MARKER",
+    "ARCHIVE_MARKER",
     "MAX_COMMENT_CHARS",
     "build_review_body",
     "build_sticky_comment",
@@ -103,6 +107,8 @@ def post_review_to_github(
     cost_basis: str = "",
     config_source: str = "",
     auto_resolve: bool = True,
+    prior_state: ReviewState | None = None,
+    departed_paths: frozenset[str] | None = None,
 ) -> bool:
     """Post (or update) the sticky review comment and inline findings.
 
@@ -127,6 +133,10 @@ def post_review_to_github(
             came from, shown under the review body's run stats.
         auto_resolve: ``review.auto_resolve``. When false, an addressed thread
             still gets its banner but is left for a human to resolve.
+        prior_state: Artifact or ledger state. When omitted, the sticky blob
+            is migrated (findings and runs only).
+        departed_paths: Paths that left the diff this round (deletes / rename
+            sources). Their open findings may resolve.
 
     Returns:
         True when posting succeeded; False on failure or when GitHub context is
@@ -138,7 +148,11 @@ def post_review_to_github(
         return False
 
     prompt_questions = question_map or {}
-    comment_id, prior_state = _load_prior_state(reporter=gh_reporter)
+    comment_id, sticky_state = _load_prior_state(reporter=gh_reporter)
+    if prior_state is None or not (
+        prior_state.coverage or prior_state.runs or prior_state.findings
+    ):
+        prior_state = sticky_state
     diff_lines = gh_reporter.fetch_pr_diff_lines()
     head_sha = result.metadata.head_ref
 
@@ -147,8 +161,8 @@ def post_review_to_github(
         inline_failure: InlinePostFailure | None,
         comment_ids: dict[str, int] | None = None,
     ) -> str:
-        """Render the sticky body against the unchanged prior state."""
-        return build_sticky_comment(
+        """Render the primary sticky body against the unchanged prior state."""
+        primary, archive = build_sticky_bodies(
             result=result,
             prior_state=prior_state,
             head_sha=head_sha,
@@ -162,7 +176,12 @@ def post_review_to_github(
             inline_comment_ids=comment_ids,
             repo=gh_reporter.repo or "",
             pr_number=gh_reporter.pr_number,
+            departed_paths=departed_paths,
         )
+        render.archive = archive  # type: ignore[attr-defined]
+        return primary
+
+    render.archive = None  # type: ignore[attr-defined]
 
     inline_findings, fallback = _partition_findings(
         findings=result.findings,
@@ -176,6 +195,8 @@ def post_review_to_github(
         findings=result.findings,
         round_number=prior_state.next_round,
         head_sha=head_sha,
+        reviewed_paths=matcher_reviewed_paths(result=result),
+        departed_paths=departed_paths,
     )
 
     # A finding that maps to no line in the diff never gets an inline comment,
@@ -193,6 +214,10 @@ def post_review_to_github(
         reporter=gh_reporter,
         body=render(inline_failure=failure),
         comment_id=comment_id,
+    )
+    _upsert_archive(
+        reporter=gh_reporter,
+        body=getattr(render, "archive", None),
     )
 
     if inline_findings:
@@ -261,6 +286,10 @@ def post_review_to_github(
             failure=failure,
             comment_ids=comment_ids,
             comment_id=comment_id,
+        )
+        _upsert_archive(
+            reporter=gh_reporter,
+            body=getattr(render, "archive", None),
         )
 
     return success
@@ -653,6 +682,7 @@ def post_review_error_to_github(
     pr_number: int | None = None,
     repo: str | None = None,
     reporter: GitHubPRReporter | None = None,
+    prior_state: ReviewState | None = None,
 ) -> bool:
     """Post (or update) the sticky comment with a formatted API-error message.
 
@@ -668,6 +698,9 @@ def post_review_error_to_github(
         pr_number: Optional PR number override.
         repo: Optional repository override (owner/name).
         reporter: Optional preconfigured GitHub reporter.
+        prior_state: Artifact or local ledger already loaded for this
+            invocation. When set, the error sticky re-renders from it
+            instead of decoding a leftover blob.
 
     Returns:
         True when posting succeeded; False otherwise.
@@ -676,7 +709,11 @@ def post_review_error_to_github(
     if not gh_reporter.is_available():
         logger.warning("GitHub PR context not available — skipping error posting")
         return False
-    comment_id, prior_state = _load_prior_state(reporter=gh_reporter)
+    comment_id, sticky_state = _load_prior_state(reporter=gh_reporter)
+    if prior_state is None or not (
+        prior_state.coverage or prior_state.runs or prior_state.findings
+    ):
+        prior_state = sticky_state
     body = format_error_comment(
         error=error,
         provider=provider,
@@ -710,6 +747,24 @@ def _load_prior_state(
         return None, ReviewState()
     comment_id, prior_body = found
     return comment_id, parse_review_state_v2(body=prior_body)
+
+
+def _upsert_archive(
+    *,
+    reporter: GitHubPRReporter,
+    body: str | None,
+) -> None:
+    """Create or update the history-archive sticky when one was rendered.
+
+    Args:
+        reporter: GitHub reporter used to find and write the archive.
+        body: Archive Markdown, or ``None`` when history still fits.
+    """
+    if not body:
+        return
+    found = reporter.find_issue_comment(marker=ARCHIVE_MARKER)
+    comment_id = found[0] if found is not None else None
+    _upsert_sticky(reporter=reporter, body=body, comment_id=comment_id)
 
 
 def _upsert_sticky(

--- a/lintro/ai/review/github_constants.py
+++ b/lintro/ai/review/github_constants.py
@@ -7,6 +7,9 @@ import re
 from lintro.ai.review.models.review_finding import Severity
 
 STICKY_MARKER = "<!-- lintro-ai-review -->"
+ARCHIVE_MARKER = "<!-- lintro-ai-review-archive -->"
+# Split history into a second comment before GitHub's hard cap.
+PRIMARY_SOFT_LIMIT = 56_000
 STATE_MARKER_PREFIX = "<!-- lintro-ai-review-state:"
 STATE_MARKER_SUFFIX = "-->"
 # Current review-state schema version. v2 adds per-run statistics and
@@ -39,8 +42,9 @@ _FOOTER = (
 #: One-line footer of the v5 sticky comment (#1909). Names where finding detail
 #: actually lives, so the sticky is read as an index rather than a duplicate.
 STICKY_FOOTER = (
-    "<sub>🤖 lintro · finding details on inline comments · updates in place on "
-    "every push · `~` = estimated locally (provider did not report usage)</sub>"
+    "<sub>🤖 lintro review · findings are commented inline · "
+    "[how to read this report](https://github.com/lgtm-hq/py-lintro/blob/main/"
+    "docs/ai-review-report.md)</sub>"
 )
 
 _MENTION_RE = re.compile(r"(?<![\w/@.-])@(?=[A-Za-z0-9])")

--- a/lintro/ai/review/github_errors.py
+++ b/lintro/ai/review/github_errors.py
@@ -17,11 +17,7 @@ from lintro.ai.review.github_sticky import render_state_sticky
 from lintro.ai.review.models.review_metadata import ReviewMetadata
 from lintro.ai.review.models.review_state import ReviewState
 from lintro.ai.review.models.run_record import RunRecord
-from lintro.ai.review.review_state_codec import (
-    prune_state_to_fit,
-    render_state_block,
-    renumber_if_legacy_v1,
-)
+from lintro.ai.review.review_state_codec import renumber_if_legacy_v1
 
 #: Cap on the provider error text rendered on the error-only sticky. Provider
 #: failures can carry a whole CLI JSON payload as their message, and none of it
@@ -124,26 +120,8 @@ def format_error_comment(
         lines.extend(["", "<sub>" + format_run_mechanics(metadata=metadata) + "</sub>"])
     lines.extend(["", _FOOTER])
     body = "\n".join(lines)
-    if state is not None and (state.findings or state.truncated):
-        block = render_state_block(
-            state=prune_state_to_fit(
-                state=state,
-                body=body,
-                limit=MAX_COMMENT_CHARS,
-            ),
-        )
-        if len(body) + len(block) > MAX_COMMENT_CHARS:
-            # Same floor-overflow last resort as the sticky path: keep an
-            # authentic (empty) block so a forged marker in error prose can
-            # never become the last well-formed candidate.
-            block = render_state_block(
-                state=ReviewState(runs=(), findings=(), truncated=True),
-            )
-        if len(body) + len(block) > MAX_COMMENT_CHARS:
-            # A pathological error body can overflow on its own; trim it so
-            # body + authentic block always fits the budget.
-            body = body[: MAX_COMMENT_CHARS - len(block)].rstrip()
-        body += block
+    if len(body) > MAX_COMMENT_CHARS:
+        body = body[:MAX_COMMENT_CHARS].rstrip()
     return body
 
 

--- a/lintro/ai/review/github_sticky.py
+++ b/lintro/ai/review/github_sticky.py
@@ -59,8 +59,10 @@ from lintro.ai.review.finding_matcher import (
 )
 from lintro.ai.review.github_constants import (
     _SEVERITY_EMOJI,
+    ARCHIVE_MARKER,
     MAX_COMMENT_CHARS,
     MAX_STORED_RUNS,
+    PRIMARY_SOFT_LIMIT,
     SHORT_SHA_LENGTH,
     STICKY_FOOTER,
     STICKY_MARKER,
@@ -71,8 +73,6 @@ from lintro.ai.review.github_render import (
     _fmt_int,
     _format_checklist_appendix_markdown,
     _severity_counts,
-    format_badge_tables,
-    run_stats_primary_cells,
     sanitize_comment_text,
 )
 from lintro.ai.review.models.agent_prompt_scope import AgentPromptScope
@@ -92,18 +92,44 @@ from lintro.ai.review.review_state_codec import (
 from lintro.ai.review.severity_gate import count_downgrades
 from lintro.ai.review.verdict import (
     VERDICT_RUBRIC_FINE_PRINT,
+    apply_coverage_gate,
     resolve_bullet_finding,
     verdict_label,
 )
 from lintro.ai.transport import resolve_cost_basis
 
 __all__ = [
+    "advance_review_state",
+    "build_sticky_bodies",
     "build_sticky_comment",
+    "matcher_reviewed_paths",
     "parse_review_state",
     "parse_review_state_v2",
     "render_state_sticky",
     "stamp_comment_ids",
 ]
+
+
+def matcher_reviewed_paths(*, result: ReviewResult) -> frozenset[str] | None:
+    """Return the reviewed-path set the matcher should use.
+
+    An empty ``metadata.reviewed_paths`` on a result with no incomplete
+    coverage is treated as unspecified (``None``) so disappeared findings
+    still resolve — the shape of fixture results and of reviews that ran
+    before this field was populated. A capped incomplete run that truly
+    reviewed no files keeps an empty set so unread findings stay open.
+
+    Args:
+        result: Current review result.
+
+    Returns:
+        Paths the provider read, or ``None`` when the field is unspecified.
+    """
+    if result.metadata.reviewed_paths:
+        return frozenset(result.metadata.reviewed_paths)
+    if result.coverage is not None and not result.coverage.complete:
+        return frozenset()
+    return None
 
 
 def stamp_comment_ids(
@@ -141,6 +167,7 @@ VERDICT_EMOJI: dict[ReviewVerdict, str] = {
     ReviewVerdict.CHANGES_REQUESTED: "⚠️",
     ReviewVerdict.NITS_ONLY: "🟡",
     ReviewVerdict.READY: "✅",
+    ReviewVerdict.INCOMPLETE: "⚠️",
 }
 
 #: Heading used for the reasoning section, per verdict.
@@ -149,6 +176,7 @@ _REASONING_HEADINGS: dict[ReviewVerdict, str] = {
     ReviewVerdict.CHANGES_REQUESTED: "Why changes are requested",
     ReviewVerdict.NITS_ONLY: "Why it's flagged",
     ReviewVerdict.READY: "Why it's ready",
+    ReviewVerdict.INCOMPLETE: "Why the verdict is withheld",
 }
 
 #: Noun naming the finding class that decides each verdict, for the pill.
@@ -157,6 +185,7 @@ _VERDICT_NOUNS: dict[ReviewVerdict, str] = {
     ReviewVerdict.CHANGES_REQUESTED: "warning",
     ReviewVerdict.NITS_ONLY: "nit",
     ReviewVerdict.READY: "finding",
+    ReviewVerdict.INCOMPLETE: "file",
 }
 
 #: Severity that decides each verdict, used to count the pill's subject.
@@ -183,7 +212,11 @@ for _table_name, _table in (
 # _VERDICT_SEVERITY is guarded separately because READY is deliberately absent
 # from it. Without this a new non-READY verdict would pass the loop above and
 # then KeyError inside _readiness_pill on a live PR.
-_missing = set(ReviewVerdict) - {ReviewVerdict.READY} - set(_VERDICT_SEVERITY)
+_missing = (
+    set(ReviewVerdict)
+    - {ReviewVerdict.READY, ReviewVerdict.INCOMPLETE}
+    - set(_VERDICT_SEVERITY)
+)
 if _missing:  # pragma: no cover - guards a future verdict
     raise RuntimeError(f"_VERDICT_SEVERITY missing entries for: {_missing}")
 
@@ -330,47 +363,62 @@ def build_sticky_comment(
     inline_comment_ids: Mapping[str, int] | None = None,
     repo: str = "",
     pr_number: int | None = None,
+    departed_paths: frozenset[str] | None = None,
 ) -> str:
-    """Compose the full v5 "mission control" sticky PR comment body.
+    """Compose the primary sticky body. See :func:`build_sticky_bodies`."""
+    primary, _archive = build_sticky_bodies(
+        result=result,
+        prior_runs=prior_runs,
+        prior_state=prior_state,
+        checklist_display=checklist_display,
+        question_map=question_map,
+        diff_lines=diff_lines,
+        head_sha=head_sha,
+        transport=transport,
+        auth_mode=auth_mode,
+        cost_basis=cost_basis,
+        inline_failure=inline_failure,
+        inline_comment_ids=inline_comment_ids,
+        repo=repo,
+        pr_number=pr_number,
+        departed_paths=departed_paths,
+    )
+    return primary
 
-    This round's findings are matched against the prior state, so the rendered
-    delta, the ``since`` column, and the persisted v2 blob all agree on each
-    finding's identity, first-seen round, and resolution provenance.
+
+def advance_review_state(
+    *,
+    result: ReviewResult,
+    prior_state: ReviewState | None = None,
+    prior_runs: list[dict[str, Any]] | None = None,
+    head_sha: str = "",
+    transport: str = "",
+    auth_mode: str = "",
+    cost_basis: str = "",
+    inline_comment_ids: Mapping[str, int] | None = None,
+    departed_paths: frozenset[str] | None = None,
+) -> ReviewState:
+    """Advance artifact state by one completed review round.
+
+    Matching, verdict derivation, and run-record construction are the same
+    work :func:`build_sticky_bodies` uses to render the comment, so a persist
+    path and a follow-up sticky cannot disagree about what this round did.
 
     Args:
         result: Current review result.
-        prior_runs: Legacy run records recovered from the previous sticky
-            comment's state block. Ignored when ``prior_state`` is given.
-        prior_state: Full state decoded from the previous sticky comment.
-            ``None`` for the first run on a PR.
-        checklist_display: Structured checklist visibility mode.
-        question_map: Prompt id to question text for the checklist appendix and
-            for linked questions on folded-in finding detail.
-        diff_lines: Diff line map. Retained for interface compatibility with
-            the inline-posting path; the v5 sticky indexes every open finding
-            identically whether or not it also posts inline.
-        head_sha: Head commit sha reviewed in this round; stamped onto findings
-            resolved by this round.
+        prior_state: Artifact or migrated sticky state.
+        prior_runs: Legacy run mappings. Ignored when ``prior_state`` is given.
+        head_sha: Head commit sha reviewed in this round.
         transport: Provider transport used for this round.
         auth_mode: Authentication mode used by the transport.
-        cost_basis: Provenance of the reported cost
-            (``billed`` / ``estimated`` / ``unpriceable``).
-        inline_failure: Findings whose inline comments could not be posted.
-            When set, the sticky renders a warning row above the open-findings
-            table and folds those findings' full detail back in.
-        inline_comment_ids: Finding key to the id of the inline comment that
-            carries it, captured after this round's review was submitted
-            (#1912). Stamped onto the persisted records, and used to link each
-            open finding's title to the thread that carries its detail.
-        repo: ``owner/name`` slug of the repository, used to build those links.
-        pr_number: Pull request number, likewise. Titles render unlinked when
-            either is unknown rather than as dead links.
+        cost_basis: Provenance of the reported cost.
+        inline_comment_ids: Finding key to inline comment id.
+        departed_paths: Paths that left the diff this round.
 
     Returns:
-        Complete Markdown body carrying the hidden marker and state block,
-        guaranteed to fit GitHub's comment size limit.
+        The state to persist: prior runs plus this round, matched findings,
+        and this result's coverage records.
     """
-    del diff_lines  # Interface compatibility; the v5 sticky indexes uniformly.
     state = prior_state if prior_state is not None else _state_from_runs(prior_runs)
     round_number = state.next_round
     match = match_findings(
@@ -378,10 +426,9 @@ def build_sticky_comment(
         findings=result.findings,
         round_number=round_number,
         head_sha=head_sha,
+        reviewed_paths=matcher_reviewed_paths(result=result),
+        departed_paths=departed_paths,
     )
-    # Stamp the ids before rendering, not only before persisting: the open
-    # table links each title to its thread, and a round-1 finding's id is only
-    # known on the refresh pass that passes ``inline_comment_ids`` in.
     match = replace(
         match,
         records=stamp_comment_ids(
@@ -389,7 +436,116 @@ def build_sticky_comment(
             comment_ids=inline_comment_ids,
         ),
     )
-    verdict = derive_verdict(findings=match.records)
+    findings_verdict = derive_verdict(findings=match.records)
+    if result.coverage is not None:
+        verdict = apply_coverage_gate(
+            findings_verdict=findings_verdict,
+            coverage_complete=result.coverage.complete,
+        )
+    else:
+        verdict = findings_verdict
+    open_count = sum(
+        1 for record in match.records if record.status is FindingStatus.OPEN
+    )
+    current = _run_record(
+        result=result,
+        round_number=round_number,
+        head_sha=head_sha,
+        transport=transport,
+        auth_mode=auth_mode,
+        cost_basis=cost_basis,
+        verdict=verdict,
+        resolved=len(match.resolved),
+        open_after=open_count,
+    )
+    combined_runs = [*state.runs, current]
+    truncated = state.truncated or len(combined_runs) > MAX_STORED_RUNS
+    return ReviewState(
+        version=3,
+        runs=tuple(combined_runs[-MAX_STORED_RUNS:]),
+        findings=match.records,
+        coverage=result.coverage_records,
+        flagged_files=result.flagged_files,
+        repo=state.repo,
+        pr_number=state.pr_number,
+        base_sha=state.base_sha,
+        head_sha=head_sha or state.head_sha,
+        workflow=state.workflow,
+        event=state.event,
+        run_id=state.run_id,
+        lintro_version=state.lintro_version,
+        legacy=state.legacy,
+        truncated=truncated,
+    )
+
+
+def build_sticky_bodies(
+    *,
+    result: ReviewResult,
+    prior_runs: list[dict[str, Any]] | None = None,
+    prior_state: ReviewState | None = None,
+    checklist_display: ChecklistDisplay = ChecklistDisplay.OFF,
+    question_map: dict[int, str] | None = None,
+    diff_lines: dict[str, set[int]] | None = None,
+    head_sha: str = "",
+    transport: str = "",
+    auth_mode: str = "",
+    cost_basis: str = "",
+    inline_failure: InlinePostFailure | None = None,
+    inline_comment_ids: Mapping[str, int] | None = None,
+    repo: str = "",
+    pr_number: int | None = None,
+    departed_paths: frozenset[str] | None = None,
+) -> tuple[str, str | None]:
+    """Compose the primary sticky and an optional history-archive comment.
+
+    Args:
+        result: Current review result.
+        prior_runs: Legacy run records. Ignored when ``prior_state`` is given.
+        prior_state: Artifact or migrated sticky state.
+        checklist_display: Structured checklist visibility mode.
+        question_map: Prompt id to question text.
+        diff_lines: Unused; retained for the inline-posting interface.
+        head_sha: Head commit sha reviewed in this round.
+        transport: Provider transport used for this round.
+        auth_mode: Authentication mode used by the transport.
+        cost_basis: Provenance of the reported cost.
+        inline_failure: Findings whose inline comments could not be posted.
+        inline_comment_ids: Finding key to inline comment id.
+        repo: ``owner/name`` slug used to link finding titles.
+        pr_number: Pull request number used for the same links.
+        departed_paths: Paths that left the diff this round.
+
+    Returns:
+        ``(primary, archive)``. ``archive`` is ``None`` until history would
+        push the primary past :data:`PRIMARY_SOFT_LIMIT`.
+    """
+    del diff_lines
+    state = prior_state if prior_state is not None else _state_from_runs(prior_runs)
+    round_number = state.next_round
+    match = match_findings(
+        previous=state,
+        findings=result.findings,
+        round_number=round_number,
+        head_sha=head_sha,
+        reviewed_paths=matcher_reviewed_paths(result=result),
+        departed_paths=departed_paths,
+    )
+    match = replace(
+        match,
+        records=stamp_comment_ids(
+            records=match.records,
+            comment_ids=inline_comment_ids,
+        ),
+    )
+    findings_verdict = derive_verdict(findings=match.records)
+    if result.coverage is not None:
+        verdict = apply_coverage_gate(
+            findings_verdict=findings_verdict,
+            coverage_complete=result.coverage.complete,
+        )
+    else:
+        verdict = findings_verdict
     prior = list(state.runs)
     open_count = sum(
         1 for record in match.records if record.status is FindingStatus.OPEN
@@ -407,10 +563,9 @@ def build_sticky_comment(
     )
     combined_runs = [*prior, current]
     all_runs = combined_runs[-MAX_STORED_RUNS:]
-    runs_dropped = len(all_runs) < len(combined_runs)
 
-    def assemble(*, limits: _RenderLimits) -> str:
-        """Render the whole body at the given per-section limits."""
+    def assemble(*, limits: _RenderLimits, archive_history: bool = False) -> str:
+        """Render the primary body at the given limits."""
         return _assemble_body(
             result=result,
             match=match,
@@ -426,20 +581,22 @@ def build_sticky_comment(
             limits=limits,
             repo=repo,
             pr_number=pr_number,
+            archive_history=archive_history,
         )
 
-    new_state = ReviewState(
-        runs=tuple(all_runs),
-        findings=match.records,
-        truncated=state.truncated or runs_dropped,
-    )
-    return _fit_body_with_state(
+    primary = _fit_body(
         assemble=assemble,
-        prior_run_count=len(all_runs) - 1,
+        prior_run_count=max(len(all_runs) - 1, 0),
         open_count=open_count,
-        resolved_count=len(match.records) - open_count,
-        state=new_state,
+        resolved_count=len(match.resolved),
     )
+    archive: str | None = None
+    if len(primary) > PRIMARY_SOFT_LIMIT and len(all_runs) > 1:
+        primary = assemble(limits=_RenderLimits(), archive_history=True)
+        archive = _archive_body(runs=all_runs, records=match.records)
+        if len(primary) > MAX_COMMENT_CHARS:
+            primary = _cap_body(body=primary, reserved=0)
+    return primary, archive
 
 
 def render_state_sticky(
@@ -460,26 +617,30 @@ def render_state_sticky(
     navigates by — verdict, tiles, open findings, resolved findings, history —
     is derived from state and rendered unchanged.
 
-    The state is re-emitted exactly as given: a failed round must not advance
-    the round counter or touch the tracked findings, so the caller's state
-    round-trips byte-identically unless size pruning has to intervene.
-
     Args:
-        state: State decoded from the previous sticky comment. Must carry at
-            least one run; callers with an empty state have nothing to show and
-            should render their own first-failure surface instead.
-        banner: Optional blockquote rendered directly under the header, used to
-            explain why the board is not from the current round.
-        repo: ``owner/name`` slug used to link finding titles to their threads.
+        state: Artifact or migrated sticky state. An empty state renders a
+            defined first-failure surface rather than crashing.
+        banner: Optional blockquote rendered directly under the header.
+        repo: ``owner/name`` slug used to link finding titles.
         pr_number: Pull request number used for the same links.
 
     Returns:
-        Complete Markdown body carrying the hidden marker and state block,
-        guaranteed to fit GitHub's comment size limit.
+        Primary sticky body with no hidden state blob.
     """
     records = state.findings
     runs = list(state.runs)
     latest = runs[-1] if runs else None
+    if latest is None and not records:
+        return "\n\n".join(
+            section
+            for section in (
+                STICKY_MARKER,
+                "## 🔎 Lintro Review — no prior review",
+                banner or "> No stored review state is available yet.",
+                STICKY_FOOTER,
+            )
+            if section
+        )
     open_count = sum(1 for record in records if record.status is FindingStatus.OPEN)
 
     def assemble(*, limits: _RenderLimits) -> str:
@@ -495,12 +656,11 @@ def render_state_sticky(
             pr_number=pr_number,
         )
 
-    return _fit_body_with_state(
+    return _fit_body(
         assemble=assemble,
         prior_run_count=max(len(runs) - 1, 0),
         open_count=open_count,
         resolved_count=len(records) - open_count,
-        state=state,
     )
 
 
@@ -531,33 +691,37 @@ def _assemble_state_body(
         The assembled body, without the hidden state block.
     """
     records = state.findings
+    latest = runs[-1] if runs else None
+    verdict = latest.verdict if latest is not None else derive_verdict(findings=records)
     match = FindingMatchResult(records=records)
-    total_open = sum(1 for record in records if record.status is FindingStatus.OPEN)
-    total_resolved = len(records) - total_open
+    total_resolved = sum(
+        1 for record in records if record.status is FindingStatus.RESOLVED
+    )
 
     sections: list[str] = [
         STICKY_MARKER,
-        _header(round_number=round_number, head_sha=head_sha),
+        _header(
+            round_number=round_number,
+            head_sha=head_sha,
+            verdict=verdict,
+        ),
         banner,
-        _readiness_pill(verdict=derive_verdict(findings=records), records=records),
-        _verdict_explainer(),
-        _tiles_section(records=records),
-        _open_findings_section(
-            records=_sorted_open_records(records=records, limit=limits.open),
+        _findings_round_section(
             match=match,
-            total=total_open,
+            result=None,
+            round_number=round_number,
+            head_sha=head_sha,
+            verdict=verdict,
+            limits=limits,
             repo=repo,
             pr_number=pr_number,
-        ),
-        _resolved_section(
-            records=_sorted_resolved_records(records=records, limit=limits.resolved),
-            total=total_resolved,
         ),
     ]
     history = _history_section(
         runs=runs,
         limit=limits.history,
         resolved_total=total_resolved,
+        records=records,
     )
     if history:
         sections.extend(["---", history])
@@ -711,13 +875,14 @@ def _assemble_body(
     limits: _RenderLimits,
     repo: str = "",
     pr_number: int | None = None,
+    archive_history: bool = False,
 ) -> str:
-    """Render every sticky section in order and join the non-empty ones.
+    """Render every sticky section in mockup order and join the non-empty ones.
 
     Args:
         result: Current review result.
         match: Cross-round matching outcome for this round.
-        verdict: Readiness verdict derived from the open findings.
+        verdict: Readiness verdict, including the coverage gate.
         round_number: 1-based round number for this run.
         head_sha: Head commit sha reviewed in this round.
         runs: Every retained run record, oldest first, current run last.
@@ -727,40 +892,39 @@ def _assemble_body(
         question_map: Prompt id to question text.
         inline_failure: Findings whose inline comments could not be posted.
         limits: Per-section render limits.
-        repo: ``owner/name`` slug used to link finding titles to their threads.
+        repo: ``owner/name`` slug used to link finding titles.
         pr_number: Pull request number used for the same links.
+        archive_history: When True, history expanders are replaced by a link.
 
     Returns:
-        The assembled body, without the hidden state block.
+        The assembled primary body. No hidden state blob is appended.
     """
-    open_records = _sorted_open_records(records=match.records, limit=limits.open)
     open_findings = _sorted_open_findings(
         findings=result.findings,
         limit=limits.open,
     )
-    resolved_records = _sorted_resolved_records(
-        records=match.records,
-        limit=limits.resolved,
+    total_resolved = sum(
+        1 for record in match.records if record.status is FindingStatus.RESOLVED
     )
-    total_open = sum(
-        1 for record in match.records if record.status is FindingStatus.OPEN
-    )
-    total_resolved = len(match.records) - total_open
-
     sections: list[str] = [
         STICKY_MARKER,
-        _header(round_number=round_number, head_sha=head_sha),
-        _readiness_pill(verdict=verdict, records=match.records),
-        _verdict_explainer(),
-        _delta_line(match=match, round_number=round_number),
+        _header(
+            round_number=round_number,
+            head_sha=head_sha,
+            verdict=verdict,
+        ),
+        _incomplete_banner(result=result, verdict=verdict),
+        _coverage_section(result=result, verdict=verdict),
         _summary_section(result=result),
         _reasoning_section(result=result, verdict=verdict),
-        _tiles_section(records=match.records),
         _degraded_row(failure=inline_failure),
-        _open_findings_section(
-            records=open_records,
+        _findings_round_section(
             match=match,
-            total=total_open,
+            result=result,
+            round_number=round_number,
+            head_sha=head_sha,
+            verdict=verdict,
+            limits=limits,
             repo=repo,
             pr_number=pr_number,
         ),
@@ -777,7 +941,6 @@ def _assemble_body(
                 round_number=round_number,
             ),
         ),
-        _resolved_section(records=resolved_records, total=total_resolved),
         _this_run_section(
             result=result,
             transport=transport,
@@ -790,6 +953,8 @@ def _assemble_body(
         runs=runs,
         limit=limits.history,
         resolved_total=total_resolved,
+        archive_only=archive_history,
+        records=match.records,
     )
     if history:
         sections.extend(["---", history])
@@ -800,21 +965,199 @@ def _assemble_body(
 # --- section renderers -------------------------------------------------------
 
 
-def _header(*, round_number: int, head_sha: str) -> str:
+def _header(
+    *,
+    round_number: int,
+    head_sha: str,
+    verdict: ReviewVerdict = ReviewVerdict.READY,
+) -> str:
     """Render the sticky comment's title line.
 
     Args:
         round_number: 1-based round number for this run.
         head_sha: Head commit sha reviewed in this round, possibly empty.
+        verdict: Derived readiness verdict, including INCOMPLETE.
 
     Returns:
-        The Markdown heading line.
+        The Markdown heading line with the verdict in the title.
     """
-    parts = ["## 🔎 Lintro Review", f"round {round_number}"]
+    del round_number, head_sha
+    emoji = VERDICT_EMOJI[verdict]
+    label = verdict_label(verdict=verdict)
+    return f"## 🔎 Lintro Review — {emoji} {label}"
+
+
+def _incomplete_banner(*, result: ReviewResult, verdict: ReviewVerdict) -> str:
+    """Render the Variant B withheld-verdict callout.
+
+    Args:
+        result: Current review result, possibly with coverage counts.
+        verdict: Derived verdict.
+
+    Returns:
+        A warning callout, or empty when the round is complete.
+    """
+    if verdict is not ReviewVerdict.INCOMPLETE or result.coverage is None:
+        return ""
+    counts = result.coverage
+    cap = result.metadata.max_cost_usd
+    cap_text = f"`${cap:.2f}`" if cap is not None else "the cost cap"
+    awaiting = counts.awaiting
+    eligible = counts.eligible
+    reason_map = dict(result.awaiting_reasons)
+    listed = result.awaiting_paths[:12]
+    extra = max(len(result.awaiting_paths) - len(listed), 0)
+    items: list[str] = []
+    for path in listed:
+        reason = reason_map.get(path, "")
+        label = f"`{sanitize_comment_text(path, limit=200)}`"
+        if reason:
+            label = f"{label} — {sanitize_comment_text(reason, limit=160)}"
+        items.append(label)
+    if extra:
+        items.append(f"*({extra} more)*")
+    files_block = ""
+    if items:
+        files_block = (
+            "\n>\n> <details><summary>"
+            f"{awaiting} files awaiting review</summary>\n>\n> "
+            + " · ".join(items)
+            + "\n>\n> </details>"
+        )
+    return (
+        "> [!WARNING]\n"
+        f"> **Verdict withheld — {awaiting} of {eligible} files not yet "
+        f"reviewed.** {cap_text} stopped this round after {counts.reviewed} "
+        "files. The check stays ❌ until every file is covered at HEAD; "
+        "the next round resumes with the unreviewed files first."
+        f"{files_block}\n"
+    )
+
+
+def _coverage_section(*, result: ReviewResult, verdict: ReviewVerdict) -> str:
+    """Render the Variant B coverage table.
+
+    Args:
+        result: Current review result.
+        verdict: Derived verdict.
+
+    Returns:
+        The coverage table, or empty when the round is complete.
+    """
+    if verdict is not ReviewVerdict.INCOMPLETE or result.coverage is None:
+        return ""
+    counts = result.coverage
+    return "\n".join(
+        [
+            "### Coverage this round",
+            "",
+            "| reviewed now | carried forward | awaiting review "
+            "| invalidated (re-queued) |",
+            "|:-:|:-:|:-:|:-:|",
+            (
+                f"| **{counts.reviewed}** | {counts.carried} | "
+                f"**{counts.awaiting}** | {counts.invalidated} |"
+            ),
+        ],
+    )
+
+
+def _findings_round_section(
+    *,
+    match: FindingMatchResult,
+    result: ReviewResult | None,
+    round_number: int,
+    head_sha: str,
+    verdict: ReviewVerdict,
+    limits: _RenderLimits,
+    repo: str,
+    pr_number: int | None,
+) -> str:
+    """Render the Findings heading and the combined Δ table.
+
+    Args:
+        match: Cross-round matching outcome.
+        result: Current result, or ``None`` on a state-only re-render.
+        round_number: Current round.
+        head_sha: Head sha for this round.
+        verdict: Derived verdict, including the coverage gate.
+        limits: Per-section render limits.
+        repo: Repository slug for inline links.
+        pr_number: Pull request number for inline links.
+
+    Returns:
+        The Findings section.
+    """
+    open_records = _sorted_open_records(records=match.records, limit=limits.open)
+    fixed_now = [
+        record
+        for record in match.records
+        if record.status is FindingStatus.RESOLVED
+        and record.resolved_round == round_number
+    ]
+    if limits.resolved is not None:
+        fixed_now = fixed_now[: limits.resolved]
+    coverage_label = _findings_coverage_label(result=result, verdict=verdict)
     short = _short_sha(sha=head_sha)
-    if short:
-        parts.append(f"commit `{short}`")
-    return " · ".join(parts)
+    sha_bit = f" · `{short}`" if short else ""
+    open_count = sum(
+        1 for record in match.records if record.status is FindingStatus.OPEN
+    )
+    heading = (
+        f"### Findings · Round {round_number}{sha_bit} · {coverage_label} · "
+        f"{open_count} open · {len(fixed_now)} fixed this round"
+    )
+    if not open_records and not fixed_now:
+        return f"{heading}\n\n✅ Nothing open."
+    lines = [
+        heading,
+        "",
+        "| Δ | Sev | Finding | Where | Since |",
+        "|:-:|:-:|---|---|---|",
+    ]
+    for record in open_records:
+        lines.append(
+            f"| {_delta_cell(record=record, match=match)} "
+            f"| {_severity_cell(record=record)} "
+            f"| {_finding_cell(record=record, repo=repo, pr_number=pr_number)} "
+            f"| `{_location(record=record)}` "
+            f"| round {record.since_round} |",
+        )
+    for record in fixed_now:
+        lines.append(
+            f"| ✔ fixed "
+            f"| {_severity_cell(record=record)} "
+            f"| ~~{_cell(text=record.title, limit=_TITLE_LIMIT)}~~ "
+            f"| `{_location(record=record)}` "
+            f"| round {record.since_round} |",
+        )
+    dropped = open_count - len(open_records)
+    if dropped > 0:
+        lines.extend(
+            [
+                "",
+                f"> ✂️ **{dropped} more open "
+                f"{_plural(count=dropped, noun='finding')} not listed** to fit "
+                "GitHub's size limit — see the inline comments and the workflow "
+                "run log.",
+            ],
+        )
+    return "\n".join(lines)
+
+
+def _findings_coverage_label(
+    *,
+    result: ReviewResult | None,
+    verdict: ReviewVerdict,
+) -> str:
+    """Return the coverage fragment for the Findings heading."""
+    del verdict
+    if result is None or result.coverage is None:
+        return "coverage n/a"
+    counts = result.coverage
+    if counts.complete:
+        return f"✅ {counts.covered_at_head}/{counts.eligible} at HEAD"
+    return f"⚠️ {counts.covered_at_head}/{counts.eligible} files"
 
 
 def _readiness_pill(
@@ -1258,20 +1601,31 @@ def _this_run_section(
         The ``This run`` section.
     """
     metadata = result.metadata
-    primary = run_stats_primary_cells(metadata=metadata)
-    secondary = [
-        (
-            "transport",
-            _transport_label(transport=transport, auth_mode=auth_mode),
-        ),
-        ("depth", str(metadata.depth)),
-        ("files", str(metadata.files_reviewed)),
-        ("checks", str(metadata.checklist_items)),
-        ("duration", f"{metadata.duration_seconds:.0f}s"),
-    ]
-    lines = ["**This run**", ""]
-    lines.extend(format_badge_tables(rows=[primary, secondary]))
-    return "\n".join(lines)
+    usage = metadata.token_usage
+    prefix = "~" if metadata.token_usage_estimated else ""
+    model = sanitize_comment_text(metadata.model or "unknown", limit=80)
+    source = metadata.model_source
+    model_cell = f"`{model}`" + (f" ({source})" if source else "")
+    return "\n".join(
+        [
+            "**This run**",
+            "",
+            "| model | transport | est. cost | tokens in / out | depth "
+            "| files | checks | duration |",
+            "| --- | --- | --- | --- |:-:|:-:|:-:|---|",
+            (
+                f"| {model_cell} "
+                f"| {_transport_label(transport=transport, auth_mode=auth_mode)} "
+                f"| {_fmt_cost(metadata.cost_estimate_usd, estimated=True)} "
+                f"| {prefix}{_fmt_int(int(usage.get('prompt', 0)))} / "
+                f"{prefix}{_fmt_int(int(usage.get('completion', 0)))} "
+                f"| {metadata.depth} "
+                f"| {metadata.files_reviewed} "
+                f"| {metadata.checklist_items} "
+                f"| {metadata.duration_seconds:.0f}s |"
+            ),
+        ],
+    )
 
 
 def _history_section(
@@ -1279,6 +1633,8 @@ def _history_section(
     runs: list[RunRecord],
     limit: int | None,
     resolved_total: int,
+    archive_only: bool = False,
+    records: tuple[FindingRecord, ...] = (),
 ) -> str:
     """Render the single run-history collapsible.
 
@@ -1291,6 +1647,8 @@ def _history_section(
         limit: Number of *prior* runs to include, newest first. ``None``
             includes them all.
         resolved_total: Number of findings resolved across every round.
+        archive_only: When True, emit the archive heading without expanders.
+        records: Finding records used for per-round severity tiles.
 
     Returns:
         The collapsible, or an empty string on the first round where there is
@@ -1303,7 +1661,6 @@ def _history_section(
     total_tokens = sum(run.total for run in runs)
     estimated = any(run.estimated for run in runs)
     prefix = "~" if estimated else ""
-    models = _model_counts(runs=runs)
 
     if limit is None:
         shown = runs
@@ -1314,52 +1671,35 @@ def _history_section(
         shown = [*runs[:-1][len(runs) - 1 - keep :], runs[-1]]
     dropped = len(runs) - len(shown)
 
-    summary = (
-        f"🕘 Run history — {len(runs)} runs · "
+    previous = max(len(runs) - 1, 0)
+    heading = (
+        f"### 🕘 History · {previous} previous "
+        f"{_plural(count=previous, noun='run')} · "
+        f"{resolved_total} fixed · "
         f"{_fmt_cost(total_cost, estimated=estimated)} · "
-        f"{prefix}{_fmt_compact(value=total_tokens)} tokens · "
-        f"{len(models)} {_plural(count=len(models), noun='model')}"
+        f"{prefix}{_fmt_compact(value=total_tokens)} tokens"
     )
-    badges = " · ".join(
-        [
-            "models "
-            + " ".join(
-                f"`{sanitize_comment_text(model, limit=60)}` ×{count}"
-                for model, count in models
-            ),
-            f"est. cost {_fmt_cost(total_cost, estimated=estimated)}",
-            f"tokens {prefix}{_fmt_int(total_tokens)} "
-            f"(in {prefix}{_fmt_int(sum(run.prompt for run in runs))} / "
-            f"out {prefix}{_fmt_int(sum(run.completion for run in runs))})",
-            f"findings {sum(run.p1 + run.p2 + run.p3 for run in runs)} raised · "
-            f"{resolved_total} resolved",
-        ],
-    )
-
-    lines = [
-        f"<details><summary>{summary}</summary>",
-        "",
-        badges,
-        "",
-        "| Run | Commit | Verdict | Model | Open | Fixed | Tokens (in/out) "
-        "| Est. cost | Duration |",
-        "|:-:|---|---|---|:-:|:-:|---|---|---|",
-    ]
-    for run in reversed(shown):
-        lines.append(_history_row(run=run, latest=run is runs[-1]))
-    if dropped > 0:
-        lines.extend(
-            [
-                "",
-                f"> ✂️ **{dropped} older "
-                f"{_plural(count=dropped, noun='run')} not listed** "
-                "(history truncated to fit GitHub's size limit).",
-            ],
+    if archive_only:
+        return (
+            f"{heading}\n\n"
+            "Per-round expanders live on the archive comment "
+            f"({ARCHIVE_MARKER.replace('<!-- ', '').replace(' -->', '')})."
         )
-    lines.append("")
-    lines.extend(_history_mini_summary(run=run) for run in reversed(shown[:-1]))
-    lines.extend(["", "</details>"])
-    return "\n".join(lines)
+    tiles = _tiles_section(records=records) if records else ""
+    expanders = [
+        _round_expander(run=run, records=records) for run in reversed(shown[:-1])
+    ]
+    if dropped > 0:
+        expanders.append(
+            f"> ✂️ **{dropped} older "
+            f"{_plural(count=dropped, noun='run')} not listed** "
+            "(history truncated to fit GitHub's size limit).",
+        )
+    inner = "\n\n".join(part for part in [tiles, *expanders] if part)
+    return (
+        f"{heading}\n\n<details>"
+        f"<summary>Run-by-run history</summary>\n\n{inner}\n\n</details>"
+    )
 
 
 def _history_row(*, run: RunRecord, latest: bool) -> str:
@@ -1395,6 +1735,141 @@ def _history_row(*, run: RunRecord, latest: bool) -> str:
         f"| {_fmt_cost(run.cost, estimated=run.estimated)} "
         f"| {run.duration:.0f}s |"
     )
+
+
+def _round_expander(
+    *,
+    run: RunRecord,
+    records: tuple[FindingRecord, ...],
+) -> str:
+    """Render one prior-round expander (narrative, fixed table, this-run row).
+
+    Args:
+        run: Prior run record.
+        records: All tracked findings, used for that round's fixes.
+
+    Returns:
+        A ``<details>`` block for the round.
+    """
+    short = _short_sha(sha=run.sha)
+    sha_bit = f" · <code>{short}</code>" if short else ""
+    open_after = (
+        run.open_after if run.open_after is not None else run.p1 + run.p2 + run.p3
+    )
+    fixed = 0 if run.resolved is None else run.resolved
+    prefix = "~" if run.estimated else ""
+    summary = (
+        f"<b>Round {run.round}</b>{sha_bit} · "
+        f"{VERDICT_EMOJI[run.verdict]} {verdict_label(verdict=run.verdict).lower()} · "
+        f"{fixed} fixed, {open_after} left open · "
+        f"{_fmt_cost(run.cost, estimated=run.estimated)} · "
+        f"{run.duration:.0f}s"
+    )
+    narrative = _DETAILS_TAG_RE.sub(
+        r"&lt;\1\2",
+        _cell(text=run.narrative, limit=_NARRATIVE_LIMIT),
+    )
+    lines = [
+        f"<details><summary>{summary}</summary>",
+        "",
+    ]
+    if narrative:
+        lines.extend([f"> {narrative}", ""])
+    fixed_rows = [
+        record
+        for record in records
+        if record.status is FindingStatus.RESOLVED
+        and record.resolved_round == run.round
+        and not record.is_question
+    ]
+    if fixed_rows:
+        lines.extend(
+            [
+                "**Fixed this round**",
+                "",
+                "| Sev | Finding |",
+                "|:-:|---|",
+            ],
+        )
+        for record in fixed_rows:
+            lines.append(
+                f"| {_severity_cell(record=record)} "
+                f"| ~~{_cell(text=record.title, limit=_TITLE_LIMIT)}~~ |",
+            )
+        lines.append("")
+    transport = _transport_label(transport=run.transport, auth_mode=run.auth_mode)
+    lines.extend(
+        [
+            "| model | transport | est. cost | tokens in / out | depth "
+            "| files | checks | duration |",
+            "| --- | --- | --- | --- |:-:|:-:|:-:|---|",
+            (
+                f"| `{_cell(text=run.model or 'unknown', limit=60)}` "
+                f"| {transport} "
+                f"| {_fmt_cost(run.cost, estimated=run.estimated)} "
+                f"| {prefix}{_fmt_int(run.prompt)} / "
+                f"{prefix}{_fmt_int(run.completion)} "
+                f"| {run.depth} "
+                f"| {run.files_reviewed} "
+                f"| {run.checks} "
+                f"| {run.duration:.0f}s |"
+            ),
+            "",
+            "</details>",
+        ],
+    )
+    return "\n".join(lines)
+
+
+def _archive_body(
+    *,
+    runs: list[RunRecord],
+    records: tuple[FindingRecord, ...],
+) -> str:
+    """Render the archive sticky that holds per-round expanders.
+
+    Args:
+        runs: Every retained run, oldest first.
+        records: Tracked findings.
+
+    Returns:
+        Archive comment body, truncated if it exceeds the comment budget.
+    """
+    expanders = [
+        _round_expander(run=run, records=records) for run in reversed(runs[:-1])
+    ]
+    body = "\n\n".join(
+        [
+            ARCHIVE_MARKER,
+            "## 🔎 Lintro Review — history archive",
+            "Older rounds moved here so the primary sticky can keep this-round "
+            "content. The primary comment still carries heading aggregates.",
+            *expanders,
+            STICKY_FOOTER,
+        ],
+    )
+    if len(body) <= MAX_COMMENT_CHARS:
+        return body
+    # Oldest expanders degrade to their summary line.
+    trimmed: list[str] = [
+        ARCHIVE_MARKER,
+        "## 🔎 Lintro Review — history archive",
+        "Older rounds moved here so the primary sticky can keep this-round " "content.",
+    ]
+    for run in reversed(runs[:-1]):
+        candidate = _round_expander(run=run, records=records)
+        probe = "\n\n".join([*trimmed, candidate, STICKY_FOOTER])
+        if len(probe) > MAX_COMMENT_CHARS:
+            short = _short_sha(sha=run.sha)
+            trimmed.append(
+                f"**Round {run.round}**"
+                + (f" · `{short}`" if short else "")
+                + f" · {verdict_label(verdict=run.verdict).lower()}",
+            )
+            continue
+        trimmed.append(candidate)
+    trimmed.append(STICKY_FOOTER)
+    return _cap_body(body="\n\n".join(trimmed), reserved=0)
 
 
 def _history_mini_summary(*, run: RunRecord) -> str:

--- a/lintro/ai/review/github_sticky.py
+++ b/lintro/ai/review/github_sticky.py
@@ -467,6 +467,7 @@ def advance_review_state(
         coverage=result.coverage_records,
         flagged_files=result.flagged_files,
         pending_invalidations=result.pending_invalidations,
+        consumed_flags=result.consumed_flags,
         repo=state.repo,
         pr_number=state.pr_number,
         base_sha=state.base_sha,

--- a/lintro/ai/review/github_sticky.py
+++ b/lintro/ai/review/github_sticky.py
@@ -466,6 +466,7 @@ def advance_review_state(
         findings=match.records,
         coverage=result.coverage_records,
         flagged_files=result.flagged_files,
+        pending_invalidations=result.pending_invalidations,
         repo=state.repo,
         pr_number=state.pr_number,
         base_sha=state.base_sha,

--- a/lintro/ai/review/github_sticky.py
+++ b/lintro/ai/review/github_sticky.py
@@ -113,11 +113,11 @@ __all__ = [
 def matcher_reviewed_paths(*, result: ReviewResult) -> frozenset[str] | None:
     """Return the reviewed-path set the matcher should use.
 
-    An empty ``metadata.reviewed_paths`` on a result with no incomplete
-    coverage is treated as unspecified (``None``) so disappeared findings
-    still resolve — the shape of fixture results and of reviews that ran
-    before this field was populated. A capped incomplete run that truly
-    reviewed no files keeps an empty set so unread findings stay open.
+    An empty ``metadata.reviewed_paths`` on a resume-aware result
+    (``coverage`` is set) is a true empty set — including a zero-call
+    carried round — so unread findings stay open. Fixture results and
+    reviews that predate the coverage field still treat the empty tuple
+    as unspecified (``None``) so disappeared findings can resolve.
 
     Args:
         result: Current review result.
@@ -127,7 +127,7 @@ def matcher_reviewed_paths(*, result: ReviewResult) -> frozenset[str] | None:
     """
     if result.metadata.reviewed_paths:
         return frozenset(result.metadata.reviewed_paths)
-    if result.coverage is not None and not result.coverage.complete:
+    if result.coverage is not None:
         return frozenset()
     return None
 

--- a/lintro/ai/review/import_graph.py
+++ b/lintro/ai/review/import_graph.py
@@ -1,0 +1,135 @@
+"""One-hop Python import edges among changed files (#2154).
+
+Only Python files participate. Edges are parsed from post-image content
+and restricted to the changed-file set. A change to B invalidates A
+when A imports B. A→B→C with only C changed re-enters B, not A.
+"""
+
+from __future__ import annotations
+
+import ast
+from collections.abc import Mapping
+from pathlib import PurePosixPath
+
+__all__ = ["importers_of", "parse_python_imports"]
+
+_PYTHON_SUFFIXES = frozenset({".py", ".pyi"})
+
+
+def parse_python_imports(*, source: str) -> frozenset[str]:
+    """Return dotted module names imported by *source*.
+
+    Args:
+        source: Post-image Python text. Parse errors yield no edges
+            (fail toward no extra invalidation, not fake coverage).
+
+    Returns:
+        Dotted module names from ``import`` and ``from`` statements.
+        Relative imports keep their leading dots stripped and join
+        remaining parts; they are resolved against the importer path
+        by :func:`importers_of`.
+    """
+    try:
+        tree = ast.parse(source)
+    except (SyntaxError, ValueError):
+        return frozenset()
+    collected: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name:
+                    collected.add(alias.name)
+        elif isinstance(node, ast.ImportFrom):
+            module = node.module or ""
+            if node.level:
+                collected.add("." * node.level + module)
+            elif module:
+                collected.add(module)
+    return frozenset(collected)
+
+
+def importers_of(
+    *,
+    changed_paths: set[str],
+    contents: Mapping[str, str],
+    directly_changed: set[str],
+) -> dict[str, set[str]]:
+    """Map each directly-changed path to one-hop importers.
+
+    Args:
+        changed_paths: All changed repository-relative paths.
+        contents: Post-image text keyed by path (missing keys skipped).
+        directly_changed: Paths whose patch hash changed this round.
+
+    Returns:
+        ``{changed_path: {importer, ...}}`` for Python importers that
+        live in *changed_paths* and import a directly-changed file.
+    """
+    python_paths = {path for path in changed_paths if _is_python(path)}
+    module_to_path = {_module_name(path): path for path in python_paths}
+    reverse: dict[str, set[str]] = {path: set() for path in directly_changed}
+    for importer in python_paths:
+        source = contents.get(importer)
+        if source is None:
+            continue
+        imported = _resolve_imports(
+            importer=importer,
+            raw_names=parse_python_imports(source=source),
+            module_to_path=module_to_path,
+        )
+        for target in imported & directly_changed:
+            if target != importer:
+                reverse.setdefault(target, set()).add(importer)
+    return reverse
+
+
+def _is_python(path: str) -> bool:
+    """Return whether *path* is a Python source file."""
+    return PurePosixPath(path).suffix.lower() in _PYTHON_SUFFIXES
+
+
+def _module_name(path: str) -> str:
+    """Convert a repository path to a dotted module name."""
+    posix = PurePosixPath(path)
+    parts = list(posix.with_suffix("").parts)
+    if parts and parts[-1] == "__init__":
+        parts = parts[:-1]
+    return ".".join(parts)
+
+
+def _resolve_imports(
+    *,
+    importer: str,
+    raw_names: frozenset[str],
+    module_to_path: Mapping[str, str],
+) -> set[str]:
+    """Resolve imported names onto changed-file paths."""
+    resolved: set[str] = set()
+    importer_mod = _module_name(importer)
+    importer_pkg = (
+        importer_mod.rsplit(".", 1)[0] if "." in importer_mod else importer_mod
+    )
+    for raw in raw_names:
+        if raw.startswith("."):
+            level = len(raw) - len(raw.lstrip("."))
+            remainder = raw[level:]
+            pkg_parts = importer_pkg.split(".") if importer_pkg else []
+            if level > 1:
+                pkg_parts = pkg_parts[: -(level - 1)]
+            if remainder:
+                pkg_parts = [*pkg_parts, *remainder.split(".")]
+            candidate = ".".join(part for part in pkg_parts if part)
+        else:
+            candidate = raw
+        path = module_to_path.get(candidate)
+        if path is not None:
+            resolved.add(path)
+            continue
+        # ``from package import module`` may name a sibling file.
+        if "." in candidate:
+            continue
+        dotted = f"{importer_pkg}.{candidate}" if importer_pkg else candidate
+        path = module_to_path.get(dotted)
+        if path is not None:
+            resolved.add(path)
+    return resolved

--- a/lintro/ai/review/models/coverage_counts.py
+++ b/lintro/ai/review/models/coverage_counts.py
@@ -1,0 +1,74 @@
+"""Per-round coverage counters for history and the sticky (#2154)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from lintro.ai.review.models._coerce import coerce_int
+
+__all__ = ["CoverageCounts"]
+
+
+@dataclass(frozen=True, slots=True)
+class CoverageCounts:
+    """How this round treated the review-eligible file set.
+
+    Attributes:
+        reviewed: Files the provider actually read this round.
+        carried: Unchanged covered files inherited at zero cost.
+        awaiting: Eligible files not yet covered at HEAD.
+        invalidated: Covered files re-queued (group/import/flag).
+        eligible: Review-eligible denominator (100% = this count).
+    """
+
+    reviewed: int = 0
+    carried: int = 0
+    awaiting: int = 0
+    invalidated: int = 0
+    eligible: int = 0
+
+    @property
+    def covered_at_head(self) -> int:
+        """Return files whose current hash is covered after this round."""
+        return max(self.eligible - self.awaiting, 0)
+
+    @property
+    def complete(self) -> bool:
+        """Return whether every eligible file is covered at HEAD."""
+        return self.awaiting == 0
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize the counters.
+
+        Returns:
+            JSON-serializable mapping.
+        """
+        return {
+            "reviewed": self.reviewed,
+            "carried": self.carried,
+            "awaiting": self.awaiting,
+            "invalidated": self.invalidated,
+            "eligible": self.eligible,
+            "covered_at_head": self.covered_at_head,
+            "complete": self.complete,
+        }
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any] | None) -> CoverageCounts:
+        """Parse counters from untrusted JSON.
+
+        Args:
+            payload: Decoded mapping, or ``None``.
+
+        Returns:
+            Parsed counters; missing keys become zero.
+        """
+        data = payload or {}
+        return cls(
+            reviewed=coerce_int(data.get("reviewed")),
+            carried=coerce_int(data.get("carried")),
+            awaiting=coerce_int(data.get("awaiting")),
+            invalidated=coerce_int(data.get("invalidated")),
+            eligible=coerce_int(data.get("eligible")),
+        )

--- a/lintro/ai/review/models/coverage_record.py
+++ b/lintro/ai/review/models/coverage_record.py
@@ -1,0 +1,77 @@
+"""One file's coverage entry keyed by ``(path, hash)`` (#2154)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from lintro.ai.review.models._coerce import coerce_int
+
+__all__ = ["CoverageRecord"]
+
+
+@dataclass(frozen=True, slots=True)
+class CoverageRecord:
+    """A reviewed file at one normalized patch hash.
+
+    The lookup key is ``(path, hash)``. ``reviewed_sha`` is metadata so a
+    content-identical rebase does not drop coverage.
+
+    Attributes:
+        path: Repository-relative file path.
+        patch_hash: Normalized ``+``/``-`` hash at review time.
+        reviewed_sha: Head SHA when this entry was written (advisory).
+        round: Round number that produced the entry.
+        stopped_reason: Empty when the file finished; otherwise the
+            mid-round stop that checkpointed this entry.
+    """
+
+    path: str
+    patch_hash: str
+    reviewed_sha: str = ""
+    round: int = 1
+    stopped_reason: str = ""
+
+    @property
+    def identity(self) -> tuple[str, str]:
+        """Return the coverage lookup key."""
+        return (self.path, self.patch_hash)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize the record for the artifact envelope.
+
+        Returns:
+            JSON-serializable mapping.
+        """
+        payload: dict[str, Any] = {
+            "path": self.path,
+            "hash": self.patch_hash,
+            "reviewed_sha": self.reviewed_sha,
+            "round": self.round,
+        }
+        if self.stopped_reason:
+            payload["stopped_reason"] = self.stopped_reason
+        return payload
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> CoverageRecord | None:
+        """Parse a coverage record from untrusted JSON.
+
+        Args:
+            payload: Decoded mapping.
+
+        Returns:
+            The record, or ``None`` when required fields are missing.
+            Callers drop invalid entries (fail toward more review).
+        """
+        path = str(payload.get("path", "")).strip()
+        patch_hash = str(payload.get("hash", "")).strip()
+        if not path or not patch_hash:
+            return None
+        return cls(
+            path=path,
+            patch_hash=patch_hash,
+            reviewed_sha=str(payload.get("reviewed_sha", "")),
+            round=coerce_int(payload.get("round"), default=1) or 1,
+            stopped_reason=str(payload.get("stopped_reason", "")),
+        )

--- a/lintro/ai/review/models/flagged_file.py
+++ b/lintro/ai/review/models/flagged_file.py
@@ -1,0 +1,58 @@
+"""Reviewer-proposed re-read request with a reason (#2154)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+__all__ = ["FlaggedFile"]
+
+
+@dataclass(frozen=True, slots=True)
+class FlaggedFile:
+    """A model-flagged file that should re-enter the review queue.
+
+    Guards (applied by the classifier, not this record): allowlist to PR
+    changed files; one-way covered→needs-review; capped per round; same
+    ``(path, hash)`` flagged once.
+
+    Attributes:
+        path: Repository-relative path.
+        reason: Why the reviewer asked for another look.
+        patch_hash: Hash at flag time, when known.
+    """
+
+    path: str
+    reason: str
+    patch_hash: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize the flag.
+
+        Returns:
+            JSON-serializable mapping.
+        """
+        payload: dict[str, Any] = {"path": self.path, "reason": self.reason}
+        if self.patch_hash:
+            payload["hash"] = self.patch_hash
+        return payload
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> FlaggedFile | None:
+        """Parse a flag from untrusted JSON.
+
+        Args:
+            payload: Decoded mapping.
+
+        Returns:
+            The flag, or ``None`` when path or reason is empty.
+        """
+        path = str(payload.get("path", "")).strip()
+        reason = str(payload.get("reason", "")).strip()
+        if not path or not reason:
+            return None
+        return cls(
+            path=path,
+            reason=reason,
+            patch_hash=str(payload.get("hash", "")).strip(),
+        )

--- a/lintro/ai/review/models/review_result.py
+++ b/lintro/ai/review/models/review_result.py
@@ -6,7 +6,10 @@ from dataclasses import dataclass, field
 
 from lintro.ai.review.enums.review_verdict import ReviewVerdict
 from lintro.ai.review.models.checklist_answer import ChecklistAnswer
+from lintro.ai.review.models.coverage_counts import CoverageCounts
+from lintro.ai.review.models.coverage_record import CoverageRecord
 from lintro.ai.review.models.file_assessment import FileAssessment
+from lintro.ai.review.models.flagged_file import FlaggedFile
 from lintro.ai.review.models.review_finding import ReviewFinding, Severity
 from lintro.ai.review.models.review_metadata import ReviewMetadata
 from lintro.ai.review.models.review_summary import ReviewSummary
@@ -29,6 +32,13 @@ class ReviewResult:
             ``None`` when the model omitted it.
         file_assessments: One-sentence overview per reviewed file. Empty when
             the model omitted them.
+        coverage: Per-round coverage counters, or ``None`` before resume
+            bookkeeping runs.
+        coverage_records: File-level coverage map after this round.
+        flagged_files: Guarded re-read requests for the next round.
+        awaiting_paths: Eligible paths not yet covered at HEAD, with an
+            optional flag reason in ``awaiting_reasons``.
+        awaiting_reasons: Path to reviewer flag reason for awaiting files.
     """
 
     metadata: ReviewMetadata
@@ -38,6 +48,11 @@ class ReviewResult:
     pr_summary: ReviewSummary | None = None
     verdict_reasoning: VerdictReasoning | None = None
     file_assessments: tuple[FileAssessment, ...] = field(default_factory=tuple)
+    coverage: CoverageCounts | None = None
+    coverage_records: tuple[CoverageRecord, ...] = field(default_factory=tuple)
+    flagged_files: tuple[FlaggedFile, ...] = field(default_factory=tuple)
+    awaiting_paths: tuple[str, ...] = field(default_factory=tuple)
+    awaiting_reasons: tuple[tuple[str, str], ...] = field(default_factory=tuple)
 
     @property
     def has_p1_findings(self) -> bool:
@@ -54,6 +69,15 @@ class ReviewResult:
         Returns:
             The derived readiness verdict.
         """
-        from lintro.ai.review.verdict import derive_readiness_verdict
+        from lintro.ai.review.verdict import (
+            apply_coverage_gate,
+            derive_readiness_verdict,
+        )
 
-        return derive_readiness_verdict(findings=self.findings)
+        findings_verdict = derive_readiness_verdict(findings=self.findings)
+        if self.coverage is None:
+            return findings_verdict
+        return apply_coverage_gate(
+            findings_verdict=findings_verdict,
+            coverage_complete=self.coverage.complete,
+        )

--- a/lintro/ai/review/models/review_result.py
+++ b/lintro/ai/review/models/review_result.py
@@ -40,6 +40,7 @@ class ReviewResult:
             optional flag reason in ``awaiting_reasons``.
         awaiting_reasons: Path to reviewer flag reason for awaiting files.
         pending_invalidations: Unserved group/import paths to persist.
+        consumed_flags: ``(path, hash)`` pairs already honored once.
     """
 
     metadata: ReviewMetadata
@@ -55,6 +56,7 @@ class ReviewResult:
     awaiting_paths: tuple[str, ...] = field(default_factory=tuple)
     awaiting_reasons: tuple[tuple[str, str], ...] = field(default_factory=tuple)
     pending_invalidations: tuple[tuple[str, str], ...] = field(default_factory=tuple)
+    consumed_flags: tuple[tuple[str, str], ...] = field(default_factory=tuple)
 
     @property
     def has_p1_findings(self) -> bool:

--- a/lintro/ai/review/models/review_result.py
+++ b/lintro/ai/review/models/review_result.py
@@ -39,6 +39,7 @@ class ReviewResult:
         awaiting_paths: Eligible paths not yet covered at HEAD, with an
             optional flag reason in ``awaiting_reasons``.
         awaiting_reasons: Path to reviewer flag reason for awaiting files.
+        pending_invalidations: Unserved group/import paths to persist.
     """
 
     metadata: ReviewMetadata
@@ -53,6 +54,7 @@ class ReviewResult:
     flagged_files: tuple[FlaggedFile, ...] = field(default_factory=tuple)
     awaiting_paths: tuple[str, ...] = field(default_factory=tuple)
     awaiting_reasons: tuple[tuple[str, str], ...] = field(default_factory=tuple)
+    pending_invalidations: tuple[tuple[str, str], ...] = field(default_factory=tuple)
 
     @property
     def has_p1_findings(self) -> bool:

--- a/lintro/ai/review/models/review_state.py
+++ b/lintro/ai/review/models/review_state.py
@@ -1,4 +1,4 @@
-"""Versioned review state persisted in the sticky comment's hidden blob."""
+"""Versioned review state for artifacts and legacy sticky blobs (#2154)."""
 
 from __future__ import annotations
 
@@ -6,7 +6,9 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from lintro.ai.review.enums.finding_status import FindingStatus
+from lintro.ai.review.models.coverage_record import CoverageRecord
 from lintro.ai.review.models.finding_record import FindingRecord
+from lintro.ai.review.models.flagged_file import FlaggedFile
 from lintro.ai.review.models.run_record import RunRecord
 
 __all__ = ["ReviewState"]
@@ -16,17 +18,42 @@ __all__ = ["ReviewState"]
 class ReviewState:
     """Machine-readable review history for one pull request.
 
+    Authoritative CI state lives in workflow artifacts (schema 3).
+    Schema 2 sticky blobs still decode for one-time migration of
+    findings and runs; coverage is never seeded from a comment.
+
     Attributes:
-        version: Schema version of the decoded blob.
+        version: Schema version of the decoded payload.
         runs: Per-round statistics, oldest first.
         findings: Tracked findings (open and resolved) across all rounds.
-        truncated: True when older runs or resolved findings were pruned to
-            keep the sticky comment under GitHub's size limit.
+        coverage: File-level coverage records keyed ``(path, hash)``.
+        flagged_files: Guarded reviewer re-read requests.
+        repo: ``owner/name`` that produced the state.
+        pr_number: Pull request number, or ``None`` for a local branch run.
+        base_sha: Base commit when the state was written.
+        head_sha: Head commit when the state was written.
+        workflow: Trusted workflow filename (CI only).
+        event: Workflow event (CI only).
+        run_id: Actions run id that wrote the state.
+        lintro_version: Lintro version that wrote the state.
+        legacy: True when findings/runs were seeded from a sticky blob.
+        truncated: True when older runs or resolved findings were pruned.
     """
 
-    version: int = 2
+    version: int = 3
     runs: tuple[RunRecord, ...] = field(default_factory=tuple)
     findings: tuple[FindingRecord, ...] = field(default_factory=tuple)
+    coverage: tuple[CoverageRecord, ...] = field(default_factory=tuple)
+    flagged_files: tuple[FlaggedFile, ...] = field(default_factory=tuple)
+    repo: str = ""
+    pr_number: int | None = None
+    base_sha: str = ""
+    head_sha: str = ""
+    workflow: str = ""
+    event: str = ""
+    run_id: str = ""
+    lintro_version: str = ""
+    legacy: bool = False
     truncated: bool = False
 
     @property
@@ -67,3 +94,86 @@ class ReviewState:
         if self.truncated:
             payload["truncated"] = True
         return payload
+
+    def to_artifact_dict(self) -> dict[str, Any]:
+        """Serialize the schema-3 artifact envelope.
+
+        Returns:
+            JSON-serializable mapping with identity metadata and coverage.
+        """
+        payload: dict[str, Any] = {
+            "schema_version": 3,
+            "version": 3,
+            "repo": self.repo,
+            "pr_number": self.pr_number,
+            "base_sha": self.base_sha,
+            "head_sha": self.head_sha,
+            "workflow": self.workflow,
+            "event": self.event,
+            "run_id": self.run_id,
+            "lintro_version": self.lintro_version,
+            "legacy": self.legacy,
+            "runs": [run.to_dict() for run in self.runs],
+            "findings": [record.to_dict() for record in self.findings],
+            "coverage": [record.to_dict() for record in self.coverage],
+            "flagged_files": [flag.to_dict() for flag in self.flagged_files],
+        }
+        if self.truncated:
+            payload["truncated"] = True
+        return payload
+
+    @classmethod
+    def from_artifact_dict(cls, payload: dict[str, Any]) -> ReviewState:
+        """Parse a schema-3 envelope; unknown coverage rows are dropped.
+
+        Args:
+            payload: Decoded JSON mapping.
+
+        Returns:
+            Parsed state. Invalid coverage/flag rows are omitted.
+        """
+        coverage: list[CoverageRecord] = []
+        for raw in payload.get("coverage") or []:
+            if isinstance(raw, dict):
+                coverage_row = CoverageRecord.from_dict(raw)
+                if coverage_row is not None:
+                    coverage.append(coverage_row)
+        flagged: list[FlaggedFile] = []
+        for raw in payload.get("flagged_files") or []:
+            if isinstance(raw, dict):
+                flag_row = FlaggedFile.from_dict(raw)
+                if flag_row is not None:
+                    flagged.append(flag_row)
+        pr_raw = payload.get("pr_number")
+        pr_number: int | None
+        try:
+            pr_number = int(pr_raw) if pr_raw not in (None, "") else None
+        except (TypeError, ValueError):
+            pr_number = None
+        return cls(
+            version=3,
+            runs=tuple(
+                RunRecord.from_dict(item)
+                for item in payload.get("runs") or []
+                if isinstance(item, dict)
+            ),
+            findings=tuple(
+                record
+                for item in payload.get("findings") or []
+                if isinstance(item, dict)
+                for record in (FindingRecord.from_dict(item),)
+                if record is not None
+            ),
+            coverage=tuple(coverage),
+            flagged_files=tuple(flagged),
+            repo=str(payload.get("repo", "")),
+            pr_number=pr_number,
+            base_sha=str(payload.get("base_sha", "")),
+            head_sha=str(payload.get("head_sha", "")),
+            workflow=str(payload.get("workflow", "")),
+            event=str(payload.get("event", "")),
+            run_id=str(payload.get("run_id", "")),
+            lintro_version=str(payload.get("lintro_version", "")),
+            legacy=bool(payload.get("legacy", False)),
+            truncated=bool(payload.get("truncated", False)),
+        )

--- a/lintro/ai/review/models/review_state.py
+++ b/lintro/ai/review/models/review_state.py
@@ -31,6 +31,8 @@ class ReviewState:
         pending_invalidations: Unserved group/import re-reads, as
             ``(path, need)`` pairs. Survives a capped round so the next
             empty push still queues those files without round livelock.
+        consumed_flags: ``(path, hash)`` pairs already honored once so a
+            repeat flag cannot re-queue the same unchanged file.
         repo: ``owner/name`` that produced the state.
         pr_number: Pull request number, or ``None`` for a local branch run.
         base_sha: Base commit when the state was written.
@@ -49,6 +51,7 @@ class ReviewState:
     coverage: tuple[CoverageRecord, ...] = field(default_factory=tuple)
     flagged_files: tuple[FlaggedFile, ...] = field(default_factory=tuple)
     pending_invalidations: tuple[tuple[str, str], ...] = field(default_factory=tuple)
+    consumed_flags: tuple[tuple[str, str], ...] = field(default_factory=tuple)
     repo: str = ""
     pr_number: int | None = None
     base_sha: str = ""
@@ -125,6 +128,10 @@ class ReviewState:
                 {"path": path, "need": need}
                 for path, need in self.pending_invalidations
             ],
+            "consumed_flags": [
+                {"path": path, "hash": patch_hash}
+                for path, patch_hash in self.consumed_flags
+            ],
         }
         if self.truncated:
             payload["truncated"] = True
@@ -175,6 +182,7 @@ class ReviewState:
             coverage=tuple(coverage),
             flagged_files=tuple(flagged),
             pending_invalidations=_pending_from_payload(payload),
+            consumed_flags=_consumed_from_payload(payload),
             repo=str(payload.get("repo", "")),
             pr_number=pr_number,
             base_sha=str(payload.get("base_sha", "")),
@@ -204,4 +212,22 @@ def _pending_from_payload(
         need = str(item.get("need", "")).strip()
         if path and need in allowed:
             parsed.append((path, need))
+    return tuple(parsed)
+
+
+def _consumed_from_payload(
+    payload: dict[str, Any],
+) -> tuple[tuple[str, str], ...]:
+    """Parse honored flag identities from an artifact mapping."""
+    raw = payload.get("consumed_flags") or []
+    parsed: list[tuple[str, str]] = []
+    if not isinstance(raw, list):
+        return ()
+    for item in raw:
+        if not isinstance(item, dict):
+            continue
+        path = str(item.get("path", "")).strip()
+        patch_hash = str(item.get("hash", "")).strip()
+        if path and patch_hash:
+            parsed.append((path, patch_hash))
     return tuple(parsed)

--- a/lintro/ai/review/models/review_state.py
+++ b/lintro/ai/review/models/review_state.py
@@ -28,6 +28,9 @@ class ReviewState:
         findings: Tracked findings (open and resolved) across all rounds.
         coverage: File-level coverage records keyed ``(path, hash)``.
         flagged_files: Guarded reviewer re-read requests.
+        pending_invalidations: Unserved group/import re-reads, as
+            ``(path, need)`` pairs. Survives a capped round so the next
+            empty push still queues those files without round livelock.
         repo: ``owner/name`` that produced the state.
         pr_number: Pull request number, or ``None`` for a local branch run.
         base_sha: Base commit when the state was written.
@@ -45,6 +48,7 @@ class ReviewState:
     findings: tuple[FindingRecord, ...] = field(default_factory=tuple)
     coverage: tuple[CoverageRecord, ...] = field(default_factory=tuple)
     flagged_files: tuple[FlaggedFile, ...] = field(default_factory=tuple)
+    pending_invalidations: tuple[tuple[str, str], ...] = field(default_factory=tuple)
     repo: str = ""
     pr_number: int | None = None
     base_sha: str = ""
@@ -117,6 +121,10 @@ class ReviewState:
             "findings": [record.to_dict() for record in self.findings],
             "coverage": [record.to_dict() for record in self.coverage],
             "flagged_files": [flag.to_dict() for flag in self.flagged_files],
+            "pending_invalidations": [
+                {"path": path, "need": need}
+                for path, need in self.pending_invalidations
+            ],
         }
         if self.truncated:
             payload["truncated"] = True
@@ -166,6 +174,7 @@ class ReviewState:
             ),
             coverage=tuple(coverage),
             flagged_files=tuple(flagged),
+            pending_invalidations=_pending_from_payload(payload),
             repo=str(payload.get("repo", "")),
             pr_number=pr_number,
             base_sha=str(payload.get("base_sha", "")),
@@ -177,3 +186,22 @@ class ReviewState:
             legacy=bool(payload.get("legacy", False)),
             truncated=bool(payload.get("truncated", False)),
         )
+
+
+def _pending_from_payload(
+    payload: dict[str, Any],
+) -> tuple[tuple[str, str], ...]:
+    """Parse pending invalidation pairs from an artifact mapping."""
+    raw = payload.get("pending_invalidations") or []
+    parsed: list[tuple[str, str]] = []
+    if not isinstance(raw, list):
+        return ()
+    allowed = {"group_invalidated", "import_invalidated"}
+    for item in raw:
+        if not isinstance(item, dict):
+            continue
+        path = str(item.get("path", "")).strip()
+        need = str(item.get("need", "")).strip()
+        if path and need in allowed:
+            parsed.append((path, need))
+    return tuple(parsed)

--- a/lintro/ai/review/orchestrator.py
+++ b/lintro/ai/review/orchestrator.py
@@ -52,6 +52,7 @@ from lintro.ai.review.cli_limits import (
     tighter_findings_cap,
 )
 from lintro.ai.review.coverage import (
+    carry_unserved_flags,
     inherit_same_round_paths,
     pending_invalidations_for,
 )
@@ -1011,7 +1012,11 @@ async def run_review_async(
         allowed_paths=set(resume.queue),
         eligible_paths=set(resume.eligible),
     )
-    flagged_files = (*payload_flags, *converted_flags)
+    flagged_files = carry_unserved_flags(
+        new_flags=(*payload_flags, *converted_flags),
+        prior_flags=prior_state.flagged_files if prior_state is not None else (),
+        covered_now=covered_now,
+    )
     awaiting_paths = tuple(
         item.path
         for item in resume.classified
@@ -1043,7 +1048,7 @@ async def run_review_async(
         awaiting_reasons=awaiting_reasons,
         pending_invalidations=pending_invalidations_for(
             classified=resume.classified,
-            reviewed_now=actually_reviewed,
+            reviewed_now=covered_now,
         ),
     )
 

--- a/lintro/ai/review/orchestrator.py
+++ b/lintro/ai/review/orchestrator.py
@@ -51,6 +51,7 @@ from lintro.ai.review.cli_limits import (
     resolve_cli_findings_cap,
     tighter_findings_cap,
 )
+from lintro.ai.review.coverage import inherit_same_round_paths
 from lintro.ai.review.custom_agent_runner import (
     CustomAgentPassResult,
     run_custom_agent_passes,
@@ -742,7 +743,7 @@ async def run_review_async(
         force_full=force_full,
     )
     if resume.queue:
-        chunks = filter_chunks(chunks=chunks, queue=set(resume.queue))
+        chunks = filter_chunks(chunks=chunks, queue=resume.queue)
     elif run_builtin_checklist:
         chunks = []
     agent_selection = select_custom_agents(
@@ -982,8 +983,14 @@ async def run_review_async(
 
     completed_files = {path for partial in partials for path in partial.files}
     agent_files = {path for item in custom_results for path in item.files}
-    reviewed_now = tuple(
-        path for path in resume.queue if path in completed_files or path in agent_files
+    reviewed_now = inherit_same_round_paths(
+        reviewed_now=tuple(
+            path
+            for path in resume.queue
+            if path in completed_files or path in agent_files
+        ),
+        eligible_paths=resume.eligible,
+        current_hashes=resume.hashes,
     )
     coverage = resume.counts(reviewed_now=reviewed_now)
     coverage_records = records_for_reviewed(

--- a/lintro/ai/review/orchestrator.py
+++ b/lintro/ai/review/orchestrator.py
@@ -53,6 +53,7 @@ from lintro.ai.review.cli_limits import (
 )
 from lintro.ai.review.coverage import (
     carry_unserved_flags,
+    consume_served_flags,
     inherit_same_round_paths,
     pending_invalidations_for,
 )
@@ -1012,10 +1013,20 @@ async def run_review_async(
         allowed_paths=set(resume.queue),
         eligible_paths=set(resume.eligible),
     )
+    prior_flags = prior_state.flagged_files if prior_state is not None else ()
+    prior_consumed = (
+        () if force_full or prior_state is None else prior_state.consumed_flags
+    )
     flagged_files = carry_unserved_flags(
         new_flags=(*payload_flags, *converted_flags),
-        prior_flags=prior_state.flagged_files if prior_state is not None else (),
+        prior_flags=prior_flags,
         covered_now=covered_now,
+    )
+    consumed_flags = consume_served_flags(
+        prior_consumed=prior_consumed,
+        flags=(*payload_flags, *converted_flags, *prior_flags),
+        covered_now=covered_now,
+        current_hashes=resume.hashes,
     )
     awaiting_paths = tuple(
         item.path
@@ -1050,6 +1061,7 @@ async def run_review_async(
             classified=resume.classified,
             reviewed_now=covered_now,
         ),
+        consumed_flags=consumed_flags,
     )
 
 

--- a/lintro/ai/review/orchestrator.py
+++ b/lintro/ai/review/orchestrator.py
@@ -51,7 +51,10 @@ from lintro.ai.review.cli_limits import (
     resolve_cli_findings_cap,
     tighter_findings_cap,
 )
-from lintro.ai.review.coverage import inherit_same_round_paths
+from lintro.ai.review.coverage import (
+    inherit_same_round_paths,
+    pending_invalidations_for,
+)
 from lintro.ai.review.custom_agent_runner import (
     CustomAgentPassResult,
     run_custom_agent_passes,
@@ -983,19 +986,18 @@ async def run_review_async(
 
     completed_files = {path for partial in partials for path in partial.files}
     agent_files = {path for item in custom_results for path in item.files}
-    reviewed_now = inherit_same_round_paths(
-        reviewed_now=tuple(
-            path
-            for path in resume.queue
-            if path in completed_files or path in agent_files
-        ),
+    actually_reviewed = tuple(
+        path for path in resume.queue if path in completed_files or path in agent_files
+    )
+    covered_now = inherit_same_round_paths(
+        reviewed_now=actually_reviewed,
         eligible_paths=resume.eligible,
         current_hashes=resume.hashes,
     )
-    coverage = resume.counts(reviewed_now=reviewed_now)
+    coverage = resume.counts(reviewed_now=covered_now)
     coverage_records = records_for_reviewed(
         plan=resume,
-        reviewed_paths=reviewed_now,
+        reviewed_paths=covered_now,
         head_sha=context.head_ref,
         round_number=prior_state.next_round if prior_state is not None else 1,
         prior=None if force_full else prior_state,
@@ -1013,7 +1015,7 @@ async def run_review_async(
     awaiting_paths = tuple(
         item.path
         for item in resume.classified
-        if item.need is not FileReviewNeed.COVERED and item.path not in reviewed_now
+        if item.need is not FileReviewNeed.COVERED and item.path not in covered_now
     )
     awaiting_reasons = tuple(
         (item.path, item.flag_reason)
@@ -1022,8 +1024,8 @@ async def run_review_async(
     )
     metadata = replace(
         metadata,
-        reviewed_paths=reviewed_now,
-        files_reviewed=len(reviewed_now),
+        reviewed_paths=actually_reviewed,
+        files_reviewed=len(actually_reviewed),
     )
 
     return ReviewResult(
@@ -1039,6 +1041,10 @@ async def run_review_async(
         flagged_files=flagged_files,
         awaiting_paths=awaiting_paths,
         awaiting_reasons=awaiting_reasons,
+        pending_invalidations=pending_invalidations_for(
+            classified=resume.classified,
+            reviewed_now=actually_reviewed,
+        ),
     )
 
 

--- a/lintro/ai/review/orchestrator.py
+++ b/lintro/ai/review/orchestrator.py
@@ -60,6 +60,7 @@ from lintro.ai.review.custom_agents import (
     CustomAgentSpec,
     select_custom_agents,
 )
+from lintro.ai.review.enums.file_review_need import FileReviewNeed
 from lintro.ai.review.enums.file_skip_reason import FileSkipReason
 from lintro.ai.review.enums.review_strictness import ReviewStrictness
 from lintro.ai.review.errors_taxonomy import (
@@ -68,14 +69,21 @@ from lintro.ai.review.errors_taxonomy import (
 )
 from lintro.ai.review.exceptions import ReviewExecutionError
 from lintro.ai.review.file_selection import resolve_file_selection
-from lintro.ai.review.finding_parser import parse_findings
+from lintro.ai.review.finding_parser import (
+    parse_findings,
+    parse_flagged_files,
+    reject_context_findings,
+)
 from lintro.ai.review.group_labels import REL_DIRECTORY_PREFIX, REL_SINGLE_FILE
 from lintro.ai.review.models.checklist_answer import ChecklistAnswer
+from lintro.ai.review.models.coverage_counts import CoverageCounts
 from lintro.ai.review.models.file_assessment import FileAssessment
+from lintro.ai.review.models.flagged_file import FlaggedFile
 from lintro.ai.review.models.review_chunk import ReviewChunk
 from lintro.ai.review.models.review_finding import ReviewFinding
 from lintro.ai.review.models.review_metadata import ReviewMetadata
 from lintro.ai.review.models.review_result import ReviewResult
+from lintro.ai.review.models.review_state import ReviewState
 from lintro.ai.review.models.review_summary import ReviewSummary
 from lintro.ai.review.models.skipped_file import SkippedFile
 from lintro.ai.review.models.summary_bullet import SummaryBullet
@@ -97,6 +105,7 @@ from lintro.ai.review.response_recovery import (
     resolve_schema_retry_timeout,
     unstructured_review_payload,
 )
+from lintro.ai.review.resume import filter_chunks, plan_resume, records_for_reviewed
 from lintro.ai.review.sensitivity import (
     ReviewSensitivityPolicy,
     filter_findings_by_policy,
@@ -235,6 +244,8 @@ class _ChunkReviewPartial:
     pr_summary: ReviewSummary | None = None
     verdict_reasoning: VerdictReasoning | None = None
     file_assessments: tuple[FileAssessment, ...] = field(default_factory=tuple)
+    files: tuple[str, ...] = field(default_factory=tuple)
+    flagged_files: tuple[FlaggedFile, ...] = field(default_factory=tuple)
 
 
 def resolve_review_chunks(
@@ -312,9 +323,10 @@ async def _review_all_chunks(
     all completed work.
 
     Chunks are reviewed concurrently under a semaphore capped by
-    ``max_parallel_calls`` whether or not a cost cap is set (depth 1–3). A
-    ``ReviewExecutionError`` or a cost-cap stop cancels the remaining work and
-    propagates to ``run_review_async``. Depth ≥ 2 assigns each chunk a disjoint
+    ``max_parallel_calls``. Callers that enforce a cost cap pass ``1`` so the
+    resume queue cannot invert (issue #2154). A ``ReviewExecutionError`` or a
+    cost-cap stop cancels the remaining work and propagates to
+    ``run_review_async``. Depth ≥ 2 assigns each chunk a disjoint
     generated-checklist id range so merge stays deterministic under fan-out.
     """
     if len(chunks) <= 1:
@@ -533,6 +545,9 @@ def run_review(
     run_builtin_checklist: bool = True,
     workspace_root: Path | None = None,
     context_collection_seconds: float = 0.0,
+    prior_state: ReviewState | None = None,
+    force_full: bool = False,
+    enforce_cost_cap: bool = True,
 ) -> ReviewResult:
     """Execute an AI diff review from synchronous code.
 
@@ -562,6 +577,10 @@ def run_review(
             agents that declare a ``model`` override.
         context_collection_seconds: Wall-clock seconds the caller spent in
             ``collect_review_context`` (recorded in ``phase_timings``).
+        prior_state: Artifact or local-ledger state from a previous round.
+        force_full: Discard carried coverage (``--full``).
+        enforce_cost_cap: When True, honor ``ai.max_cost_usd`` and serialize
+            chunk calls so concurrency cannot violate queue order.
 
     Returns:
         Complete review result with metadata, checklist, and findings.
@@ -585,6 +604,9 @@ def run_review(
             run_builtin_checklist=run_builtin_checklist,
             workspace_root=workspace_root,
             context_collection_seconds=context_collection_seconds,
+            prior_state=prior_state,
+            force_full=force_full,
+            enforce_cost_cap=enforce_cost_cap,
         ),
     )
 
@@ -608,6 +630,9 @@ async def run_review_async(
     run_builtin_checklist: bool = True,
     workspace_root: Path | None = None,
     context_collection_seconds: float = 0.0,
+    prior_state: ReviewState | None = None,
+    force_full: bool = False,
+    enforce_cost_cap: bool = True,
 ) -> ReviewResult:
     """Execute an AI diff review with depth-controlled passes.
 
@@ -634,6 +659,10 @@ async def run_review_async(
             agents that declare a ``model`` override.
         context_collection_seconds: Wall-clock seconds the caller spent in
             ``collect_review_context`` (recorded in ``phase_timings``).
+        prior_state: Artifact or local-ledger state from a previous round.
+        force_full: Discard carried coverage (``--full``).
+        enforce_cost_cap: When True, honor ``ai.max_cost_usd`` and serialize
+            chunk calls so concurrency cannot violate queue order.
 
     Returns:
         Complete review result with metadata, checklist, and findings.
@@ -705,6 +734,17 @@ async def run_review_async(
         if run_builtin_checklist
         else []
     )
+    resume = plan_resume(
+        context=context,
+        prior=prior_state,
+        extra_skips=chunk_skips,
+        groups=tuple(tuple(chunk.files) for chunk in chunks),
+        force_full=force_full,
+    )
+    if resume.queue:
+        chunks = filter_chunks(chunks=chunks, queue=set(resume.queue))
+    elif run_builtin_checklist:
+        chunks = []
     agent_selection = select_custom_agents(
         agents=custom_agents,
         changed_paths=tuple(file.path for file in context.changed_files),
@@ -722,7 +762,9 @@ async def run_review_async(
         else ai_config
     )
     tracker = progress or NullReviewProgress()
-    budget = CostBudget(max_cost_usd=ai_config.max_cost_usd)
+    budget = CostBudget(
+        max_cost_usd=ai_config.max_cost_usd if enforce_cost_cap else None,
+    )
     # Branch on the provider's declared capability, not its identity (#1241):
     # a durable session only helps when the transport can resume one.
     # begin/end_durable_session are concrete no-ops on BaseAIProvider, so no
@@ -770,7 +812,11 @@ async def run_review_async(
                 progress=tracker,
                 repo_root=repo_root,
                 use_one_shot=use_one_shot,
-                max_parallel_calls=ai_config.max_parallel_calls,
+                max_parallel_calls=(
+                    1
+                    if enforce_cost_cap and ai_config.max_cost_usd is not None
+                    else ai_config.max_parallel_calls
+                ),
                 strictness_section=strictness_section,
                 next_generated_checklist_id=(
                     _max_checklist_id(checklist_items=checklist_items) + 1
@@ -778,20 +824,22 @@ async def run_review_async(
                 diff_budget=diff_budget,
                 completed_sink=collected,
             )
-        await run_custom_agent_passes(
-            selected=agent_selection.selected,
-            context=context,
-            provider=provider,
-            ai_config=effective_ai_config,
-            budget=budget,
-            repo_root=repo_root,
-            workspace_root=workspace_root,
-            # Never reuse the built-in review's durable session: each agent is
-            # an independent, narrowly scoped pass with its own instructions.
-            use_one_shot=True,
-            on_pass_complete=custom_results.append,
-            on_agent_failed=custom_agents_failed.append,
-        )
+        if resume.queue:
+            await run_custom_agent_passes(
+                selected=agent_selection.selected,
+                context=context,
+                provider=provider,
+                ai_config=effective_ai_config,
+                budget=budget,
+                repo_root=repo_root,
+                workspace_root=workspace_root,
+                # Never reuse the built-in review's durable session: each agent
+                # is an independent, narrowly scoped pass with its own
+                # instructions.
+                use_one_shot=True,
+                on_pass_complete=custom_results.append,
+                on_agent_failed=custom_agents_failed.append,
+            )
         provider_seconds = time.monotonic() - provider_started
         merge_started = time.monotonic()
         merged, filtered_findings, total_findings = _finalize_partials(
@@ -932,6 +980,45 @@ async def run_review_async(
         ),
     )
 
+    completed_files = {path for partial in partials for path in partial.files}
+    agent_files = {path for item in custom_results for path in item.files}
+    reviewed_now = tuple(
+        path for path in resume.queue if path in completed_files or path in agent_files
+    )
+    coverage = resume.counts(reviewed_now=reviewed_now)
+    coverage_records = records_for_reviewed(
+        plan=resume,
+        reviewed_paths=reviewed_now,
+        head_sha=context.head_ref,
+        round_number=prior_state.next_round if prior_state is not None else 1,
+        prior=None if force_full else prior_state,
+        stopped_reason=stopped_reason,
+    )
+    payload_flags = tuple(
+        flag for partial in partials for flag in partial.flagged_files
+    )
+    filtered_findings, converted_flags = reject_context_findings(
+        findings=filtered_findings,
+        allowed_paths=set(resume.queue),
+        eligible_paths=set(resume.eligible),
+    )
+    flagged_files = (*payload_flags, *converted_flags)
+    awaiting_paths = tuple(
+        item.path
+        for item in resume.classified
+        if item.need is not FileReviewNeed.COVERED and item.path not in reviewed_now
+    )
+    awaiting_reasons = tuple(
+        (item.path, item.flag_reason)
+        for item in resume.classified
+        if item.path in set(awaiting_paths) and item.flag_reason
+    )
+    metadata = replace(
+        metadata,
+        reviewed_paths=reviewed_now,
+        files_reviewed=len(reviewed_now),
+    )
+
     return ReviewResult(
         metadata=metadata,
         summary=summary,
@@ -940,6 +1027,11 @@ async def run_review_async(
         pr_summary=merged.pr_summary,
         verdict_reasoning=merged.verdict_reasoning,
         file_assessments=merged.file_assessments,
+        coverage=coverage,
+        coverage_records=coverage_records,
+        flagged_files=flagged_files,
+        awaiting_paths=awaiting_paths,
+        awaiting_reasons=awaiting_reasons,
     )
 
 
@@ -1476,7 +1568,10 @@ async def _review_chunk(
         use_one_shot=use_one_shot,
         elapsed=elapsed,
     )
-    partial = _payload_to_partial(response=response, payload=payload)
+    partial = replace(
+        _payload_to_partial(response=response, payload=payload),
+        files=tuple(chunk.files),
+    )
 
     if extra_checklist_usage is not None:
         partial = replace(
@@ -1974,6 +2069,7 @@ def _payload_to_partial(
 
     checklist = _parse_checklist(raw_checklist=payload.get("checklist", []))
     findings = parse_findings(raw_findings=payload.get("findings", []))
+    flagged_files = parse_flagged_files(raw_flags=payload.get("flagged_files"))
 
     return _ChunkReviewPartial(
         summary=summary,
@@ -1985,6 +2081,7 @@ def _payload_to_partial(
         pr_summary=pr_summary,
         verdict_reasoning=verdict_reasoning,
         file_assessments=file_assessments,
+        flagged_files=flagged_files,
     )
 
 
@@ -2189,6 +2286,7 @@ def _empty_review_result(
         summary="No changes found to review.",
         checklist=(),
         findings=(),
+        coverage=CoverageCounts(),
     )
 
 

--- a/lintro/ai/review/output.py
+++ b/lintro/ai/review/output.py
@@ -27,7 +27,7 @@ def review_result_to_dict(*, result: ReviewResult) -> dict[str, Any]:
         Dictionary representation suitable for JSON encoding.
     """
     metadata = asdict(result.metadata)
-    return {
+    payload: dict[str, Any] = {
         "metadata": metadata,
         "summary": result.summary,
         "readiness_verdict": result.readiness_verdict.value,
@@ -45,6 +45,11 @@ def review_result_to_dict(*, result: ReviewResult) -> dict[str, Any]:
         "checklist": [asdict(answer) for answer in result.checklist],
         "findings": [asdict(finding) for finding in result.findings],
     }
+    if result.coverage is not None:
+        payload["coverage"] = result.coverage.to_dict()
+        payload["partial"] = result.metadata.partial
+        payload["stopped_reason"] = result.metadata.stopped_reason
+    return payload
 
 
 def review_result_to_json(*, result: ReviewResult) -> str:

--- a/lintro/ai/review/patch_hash.py
+++ b/lintro/ai/review/patch_hash.py
@@ -1,0 +1,45 @@
+"""Normalized patch hashes for file-level review coverage (#2154).
+
+Coverage identity is ``(path, hash)``. The hash covers only added and
+removed lines so a content-identical rebase or update-branch keeps
+coverage. Context lines and hunk headers are ignored on purpose: they
+measure surrounding text, not the change. Contextual drift is the
+invalidation graph's job (ADR-0007).
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+__all__ = ["normalized_patch_hash"]
+
+
+def normalized_patch_hash(diff_text: str) -> str:
+    """Hash the added and removed lines of a unified per-file diff.
+
+    Args:
+        diff_text: Unified diff for one file (headers optional).
+
+    Returns:
+        Hex sha256 of the ``+``/``-`` payload. An empty payload (pure
+        context, file mode, or rename without body) hashes the empty
+        string so two empty changes still compare equal.
+    """
+    lines: list[str] = []
+    for raw in diff_text.splitlines():
+        if raw.startswith(
+            (
+                "+++",
+                "---",
+                "@@",
+                "diff ",
+                "index ",
+                "new file",
+                "deleted file",
+            ),
+        ):
+            continue
+        if raw.startswith(("+", "-")):
+            lines.append(raw)
+    payload = "\n".join(lines)
+    return hashlib.sha256(payload.encode("utf-8", errors="surrogateescape")).hexdigest()

--- a/lintro/ai/review/resume.py
+++ b/lintro/ai/review/resume.py
@@ -79,6 +79,7 @@ def plan_resume(
     coverage = () if prior is None or force_full else prior.coverage
     flags = () if prior is None or force_full else prior.flagged_files
     pending = () if prior is None or force_full else prior.pending_invalidations
+    consumed = () if prior is None or force_full else prior.consumed_flags
     import_targets = {
         path for path in eligible if path.rsplit("/", 1)[-1] not in BROADCAST_FILENAMES
     }
@@ -95,6 +96,7 @@ def plan_resume(
         import_importers=imports,
         flags=flags,
         pending_invalidations=pending,
+        consumed_flags=consumed,
         force_full=force_full,
     )
     return ResumePlan(

--- a/lintro/ai/review/resume.py
+++ b/lintro/ai/review/resume.py
@@ -78,6 +78,7 @@ def plan_resume(
     )
     coverage = () if prior is None or force_full else prior.coverage
     flags = () if prior is None or force_full else prior.flagged_files
+    pending = () if prior is None or force_full else prior.pending_invalidations
     import_targets = {
         path for path in eligible if path.rsplit("/", 1)[-1] not in BROADCAST_FILENAMES
     }
@@ -93,6 +94,7 @@ def plan_resume(
         groups=groups,
         import_importers=imports,
         flags=flags,
+        pending_invalidations=pending,
         force_full=force_full,
     )
     return ResumePlan(

--- a/lintro/ai/review/resume.py
+++ b/lintro/ai/review/resume.py
@@ -1,0 +1,185 @@
+"""Plan which files a resume round must send to the provider (#2154)."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+from lintro.ai.review.context.diff_parse import split_unified_diff_by_file
+from lintro.ai.review.coverage import (
+    ClassifiedFile,
+    classify_files,
+    coverage_counts,
+    hashes_for_diffs,
+    queue_paths,
+    review_eligible_paths,
+)
+from lintro.ai.review.import_graph import importers_of
+from lintro.ai.review.models.coverage_counts import CoverageCounts
+from lintro.ai.review.models.coverage_record import CoverageRecord
+from lintro.ai.review.models.review_chunk import ReviewChunk
+from lintro.ai.review.models.review_context import ReviewContext
+from lintro.ai.review.models.review_state import ReviewState
+from lintro.ai.review.models.skipped_file import SkippedFile
+
+__all__ = ["ResumePlan", "filter_chunks", "plan_resume"]
+
+
+@dataclass(frozen=True, slots=True)
+class ResumePlan:
+    """Queue and coverage bookkeeping for one resume round.
+
+    Attributes:
+        classified: Per-file classification.
+        queue: Paths that need a provider read, in cap-safe order.
+        hashes: Current normalized patch hash per path.
+        eligible: Review-eligible paths.
+    """
+
+    classified: tuple[ClassifiedFile, ...]
+    queue: tuple[str, ...]
+    hashes: dict[str, str]
+    eligible: tuple[str, ...]
+
+    def counts(self, *, reviewed_now: Sequence[str]) -> CoverageCounts:
+        """Return counters after the provider finished *reviewed_now*."""
+        return coverage_counts(
+            classified=self.classified,
+            reviewed_now=reviewed_now,
+        )
+
+
+def plan_resume(
+    *,
+    context: ReviewContext,
+    prior: ReviewState | None,
+    extra_skips: Sequence[SkippedFile] = (),
+    groups: Sequence[Sequence[str]] = (),
+    force_full: bool = False,
+) -> ResumePlan:
+    """Classify the current diff against prior coverage.
+
+    Args:
+        context: Collected review context.
+        prior: Artifact or local ledger state; empty on first run.
+        extra_skips: Chunker / agent-scope skips.
+        groups: Semantic groups from this round's chunker.
+        force_full: Discard carried coverage (``--full``).
+
+    Returns:
+        Queue and hashes for this round.
+    """
+    diffs = split_unified_diff_by_file(unified_diff=context.unified_diff)
+    hashes = hashes_for_diffs(diffs=diffs)
+    eligible = review_eligible_paths(
+        changed_files=context.changed_files,
+        skipped=(*context.skipped_files, *extra_skips),
+    )
+    coverage = () if prior is None or force_full else prior.coverage
+    flags = () if prior is None or force_full else prior.flagged_files
+    directly_changed = {
+        path
+        for path in eligible
+        if _is_directly_changed(path=path, hashes=hashes, coverage=coverage)
+    }
+    imports = importers_of(
+        changed_paths=set(eligible),
+        contents=context.post_image_files,
+        directly_changed=directly_changed,
+    )
+    classified = classify_files(
+        eligible_paths=eligible,
+        current_hashes=hashes,
+        coverage=coverage,
+        groups=groups,
+        import_importers=imports,
+        flags=flags,
+        force_full=force_full,
+    )
+    return ResumePlan(
+        classified=classified,
+        queue=queue_paths(classified=classified),
+        hashes=hashes,
+        eligible=eligible,
+    )
+
+
+def filter_chunks(
+    *,
+    chunks: list[ReviewChunk],
+    queue: set[str],
+) -> list[ReviewChunk]:
+    """Keep chunks that still contain a file needing review.
+
+    Covered group-mates stay in a mixed chunk as read-only context; the
+    chunk is dropped only when every file is already covered.
+
+    Args:
+        chunks: Chunks from the grouper (full changed-file set).
+        queue: Paths that need review.
+
+    Returns:
+        Chunks in original order, minus fully-covered ones.
+    """
+    if not queue:
+        return []
+    kept: list[ReviewChunk] = []
+    for chunk in chunks:
+        if any(path in queue for path in chunk.files):
+            kept.append(chunk)
+    return kept
+
+
+def records_for_reviewed(
+    *,
+    plan: ResumePlan,
+    reviewed_paths: Sequence[str],
+    head_sha: str,
+    round_number: int,
+    prior: ReviewState | None,
+    stopped_reason: str = "",
+) -> tuple[CoverageRecord, ...]:
+    """Merge new coverage entries onto the prior map.
+
+    Args:
+        plan: This round's plan.
+        reviewed_paths: Paths the provider actually read.
+        head_sha: Current head SHA (metadata).
+        round_number: Current round.
+        prior: Previous state.
+        stopped_reason: Mid-round stop, if any.
+
+    Returns:
+        Unioned coverage records.
+    """
+    merged: dict[tuple[str, str], CoverageRecord] = {}
+    if prior is not None:
+        for record in prior.coverage:
+            merged[record.identity] = record
+    reviewed = set(reviewed_paths)
+    for item in plan.classified:
+        if item.path not in reviewed:
+            continue
+        record = CoverageRecord(
+            path=item.path,
+            patch_hash=item.patch_hash,
+            reviewed_sha=head_sha,
+            round=round_number,
+            stopped_reason=stopped_reason,
+        )
+        merged[record.identity] = record
+    return tuple(merged.values())
+
+
+def _is_directly_changed(
+    *,
+    path: str,
+    hashes: dict[str, str],
+    coverage: Sequence[CoverageRecord],
+) -> bool:
+    """Return whether *path* has a different hash than the stored entry."""
+    current = hashes.get(path, "")
+    for record in coverage:
+        if record.path == path:
+            return record.patch_hash != current
+    return False

--- a/lintro/ai/review/resume.py
+++ b/lintro/ai/review/resume.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 
 from lintro.ai.review.context.diff_parse import split_unified_diff_by_file
 from lintro.ai.review.coverage import (
+    BROADCAST_FILENAMES,
     ClassifiedFile,
     classify_files,
     coverage_counts,
@@ -77,15 +78,13 @@ def plan_resume(
     )
     coverage = () if prior is None or force_full else prior.coverage
     flags = () if prior is None or force_full else prior.flagged_files
-    directly_changed = {
-        path
-        for path in eligible
-        if _is_directly_changed(path=path, hashes=hashes, coverage=coverage)
+    import_targets = {
+        path for path in eligible if path.rsplit("/", 1)[-1] not in BROADCAST_FILENAMES
     }
     imports = importers_of(
         changed_paths=set(eligible),
         contents=context.post_image_files,
-        directly_changed=directly_changed,
+        directly_changed=import_targets,
     )
     classified = classify_files(
         eligible_paths=eligible,
@@ -107,26 +106,30 @@ def plan_resume(
 def filter_chunks(
     *,
     chunks: list[ReviewChunk],
-    queue: set[str],
+    queue: Sequence[str],
 ) -> list[ReviewChunk]:
     """Keep chunks that still contain a file needing review.
 
     Covered group-mates stay in a mixed chunk as read-only context; the
-    chunk is dropped only when every file is already covered.
+    chunk is dropped only when every file is already covered. Remaining
+    chunks are ordered by the first queued file they contain so a
+    capped serial run cannot invert never-reviewed → changed → flagged
+    → invalidated priority.
 
     Args:
         chunks: Chunks from the grouper (full changed-file set).
-        queue: Paths that need review.
+        queue: Paths that need review, in cap-safe order.
 
     Returns:
-        Chunks in original order, minus fully-covered ones.
+        Chunks that still need work, in queue order.
     """
     if not queue:
         return []
-    kept: list[ReviewChunk] = []
-    for chunk in chunks:
-        if any(path in queue for path in chunk.files):
-            kept.append(chunk)
+    rank = {path: index for index, path in enumerate(queue)}
+    kept = [chunk for chunk in chunks if any(path in rank for path in chunk.files)]
+    kept.sort(
+        key=lambda chunk: min(rank[path] for path in chunk.files if path in rank),
+    )
     return kept
 
 
@@ -169,17 +172,3 @@ def records_for_reviewed(
         )
         merged[record.identity] = record
     return tuple(merged.values())
-
-
-def _is_directly_changed(
-    *,
-    path: str,
-    hashes: dict[str, str],
-    coverage: Sequence[CoverageRecord],
-) -> bool:
-    """Return whether *path* has a different hash than the stored entry."""
-    current = hashes.get(path, "")
-    for record in coverage:
-        if record.path == path:
-            return record.patch_hash != current
-    return False

--- a/lintro/ai/review/review_state_codec.py
+++ b/lintro/ai/review/review_state_codec.py
@@ -28,6 +28,7 @@ from lintro.ai.review.models.run_record import RunRecord
 __all__ = [
     "decode_state",
     "encode_state",
+    "legacy_state_block",
     "migrate_v1_runs",
     "prune_state_to_fit",
     "renumber_if_legacy_v1",
@@ -57,13 +58,28 @@ def render_state_block(*, state: ReviewState) -> str:
         state: State to embed.
 
     Returns:
-        The block, including its leading blank-line separator.
+        Empty string. Authoritative state lives in workflow artifacts
+        (#2154); the sticky is pure rendering and never writes a leftover
+        blob.
     """
-    return (
-        f"\n\n{STATE_MARKER_PREFIX} "
-        + encode_state(state=state)
-        + f" {STATE_MARKER_SUFFIX}"
-    )
+    del state
+    return ""
+
+
+def legacy_state_block(*, state: ReviewState) -> str:
+    """Wrap encoded state in leftover-blob markers for decode/migration tests.
+
+    New stickies never call this. The decoder still reads v1/v2 blobs so a
+    one-time migration can seed findings and runs.
+
+    Args:
+        state: State to encode.
+
+    Returns:
+        The historical HTML-comment block, including its leading blank line.
+    """
+    encoded = encode_state(state=state)
+    return f"\n\n{STATE_MARKER_PREFIX} {encoded} {STATE_MARKER_SUFFIX}"
 
 
 def _extract_payload(*, body: str) -> dict[str, Any] | None:
@@ -227,8 +243,8 @@ def decode_state(*, body: str) -> ReviewState:
 
 
 def _block_length(*, state: ReviewState) -> int:
-    """Return the rendered length of the state block for ``state``."""
-    return len(render_state_block(state=state))
+    """Return the encoded leftover-blob length used by prune."""
+    return len(legacy_state_block(state=state))
 
 
 def prune_state_to_fit(

--- a/lintro/ai/review/state_store.py
+++ b/lintro/ai/review/state_store.py
@@ -148,6 +148,7 @@ def union_states(states: Iterable[ReviewState]) -> ReviewState:
     flagged: dict[tuple[str, str], FlaggedFile] = {}
     runs: tuple[RunRecord, ...] = ()
     findings: tuple[FindingRecord, ...] = ()
+    pending: tuple[tuple[str, str], ...] = ()
     legacy = False
     truncated = False
     identity = ReviewState()
@@ -161,6 +162,7 @@ def union_states(states: Iterable[ReviewState]) -> ReviewState:
             runs = state.runs
         if state.findings:
             findings = state.findings
+        pending = state.pending_invalidations
         legacy = legacy or state.legacy
         truncated = truncated or state.truncated
     return ReviewState(
@@ -169,6 +171,7 @@ def union_states(states: Iterable[ReviewState]) -> ReviewState:
         findings=findings,
         coverage=tuple(coverage.values()),
         flagged_files=tuple(flagged.values()),
+        pending_invalidations=pending,
         repo=identity.repo,
         pr_number=identity.pr_number,
         base_sha=identity.base_sha,

--- a/lintro/ai/review/state_store.py
+++ b/lintro/ai/review/state_store.py
@@ -1,0 +1,342 @@
+"""Artifact and local-ledger backends for review state (#2154).
+
+CI writes versioned JSON parts under ``ai-review-state/`` (or
+``LINTRO_REVIEW_STATE_DIR``). The consumer unions every valid part,
+last-writer-wins per ``(path, hash)``. Local runs use
+``.lintro-cache/ai/review-state/`` with atomic replace and a named LRU.
+CI never imports a local ledger (and the reverse): trust boundary.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import tempfile
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Any
+
+from lintro.ai.review.github_constants import STATE_VERSION_V1
+from lintro.ai.review.models.coverage_record import CoverageRecord
+from lintro.ai.review.models.finding_record import FindingRecord
+from lintro.ai.review.models.flagged_file import FlaggedFile
+from lintro.ai.review.models.review_state import ReviewState
+from lintro.ai.review.models.run_record import RunRecord
+from lintro.ai.review.review_state_codec import decode_state
+
+__all__ = [
+    "ARTIFACT_STATE_VERSION",
+    "CI_STATE_DIRNAME",
+    "LOCAL_STATE_DIR",
+    "LOCAL_STATE_LRU",
+    "load_ci_state",
+    "load_local_state",
+    "migrate_legacy_sticky",
+    "state_dir",
+    "union_states",
+    "write_local_state",
+    "write_state_part",
+]
+
+ARTIFACT_STATE_VERSION = 3
+CI_STATE_DIRNAME = "ai-review-state"
+LOCAL_STATE_DIR = Path(".lintro-cache/ai/review-state")
+LOCAL_STATE_LRU = 32
+_UNSAFE_KEY = re.compile(r"[^A-Za-z0-9._-]+")
+
+
+def state_dir(*, ci: bool) -> Path:
+    """Return the directory used for this invocation's state files.
+
+    Args:
+        ci: True when running under GitHub Actions with an artifact dir.
+
+    Returns:
+        Absolute or cwd-relative path. ``LINTRO_REVIEW_STATE_DIR`` wins
+        when set so tests and the workflow can point at the download.
+    """
+    override = os.environ.get("LINTRO_REVIEW_STATE_DIR", "").strip()
+    if override:
+        return Path(override)
+    if ci or os.environ.get("GITHUB_ACTIONS") == "true":
+        return Path(CI_STATE_DIRNAME)
+    return LOCAL_STATE_DIR
+
+
+def write_state_part(
+    *,
+    state: ReviewState,
+    directory: Path,
+    sequence: int,
+    final: bool = False,
+) -> Path:
+    """Atomically write one state part (or the final snapshot).
+
+    Args:
+        state: State to persist.
+        directory: Destination directory (created if needed).
+        sequence: Monotonic part number for this run.
+        final: When True, also write ``state.json`` as the latest snapshot.
+
+    Returns:
+        Path of the part file.
+    """
+    directory.mkdir(parents=True, exist_ok=True)
+    payload = state.to_artifact_dict()
+    part = directory / f"part-{sequence:04d}.json"
+    _atomic_write_json(path=part, payload=payload)
+    if final:
+        _atomic_write_json(path=directory / "state.json", payload=payload)
+    return part
+
+
+def load_ci_state(
+    *,
+    directory: Path,
+    repo: str,
+    pr_number: int,
+) -> ReviewState:
+    """Load and union every valid part in *directory*.
+
+    Invalid, wrong-repo, wrong-PR, or unknown-version files are skipped
+    (fail toward empty coverage / more review).
+
+    Args:
+        directory: Downloaded artifact directory.
+        repo: Expected ``owner/name``.
+        pr_number: Expected pull request number.
+
+    Returns:
+        Unioned state, or empty state when nothing validates.
+    """
+    if not directory.is_dir():
+        return ReviewState()
+    parts = sorted(
+        (
+            path
+            for path in directory.iterdir()
+            if path.is_file() and path.suffix == ".json"
+        ),
+        key=lambda path: path.name,
+    )
+    loaded: list[ReviewState] = []
+    for path in parts:
+        parsed = _load_artifact_file(
+            path=path,
+            repo=repo,
+            pr_number=pr_number,
+        )
+        if parsed is not None:
+            loaded.append(parsed)
+    if not loaded:
+        return ReviewState()
+    return union_states(loaded)
+
+
+def union_states(states: Iterable[ReviewState]) -> ReviewState:
+    """Last-writer-wins union of coverage keyed by ``(path, hash)``.
+
+    Args:
+        states: Parts in ascending sequence order.
+
+    Returns:
+        Combined state. Findings and runs take the last non-empty copy
+        so a later part that finished the round wins.
+    """
+    coverage: dict[tuple[str, str], CoverageRecord] = {}
+    flagged: dict[tuple[str, str], FlaggedFile] = {}
+    runs: tuple[RunRecord, ...] = ()
+    findings: tuple[FindingRecord, ...] = ()
+    truncated = False
+    identity = ReviewState()
+    for state in states:
+        identity = state
+        for record in state.coverage:
+            coverage[record.identity] = record
+        for flag in state.flagged_files:
+            flagged[(flag.path, flag.patch_hash)] = flag
+        if state.runs:
+            runs = state.runs
+        if state.findings:
+            findings = state.findings
+        truncated = truncated or state.legacy
+    return ReviewState(
+        version=ARTIFACT_STATE_VERSION,
+        runs=runs,
+        findings=findings,
+        coverage=tuple(coverage.values()),
+        flagged_files=tuple(flagged.values()),
+        repo=identity.repo,
+        pr_number=identity.pr_number,
+        base_sha=identity.base_sha,
+        head_sha=identity.head_sha,
+        workflow=identity.workflow,
+        event=identity.event,
+        run_id=identity.run_id,
+        lintro_version=identity.lintro_version,
+        legacy=identity.legacy,
+        truncated=identity.truncated,
+    )
+
+
+def migrate_legacy_sticky(*, body: str) -> ReviewState:
+    """Seed findings and runs from a v1/v2 sticky blob.
+
+    Coverage is never seeded. Migrated history is marked ``legacy`` so
+    rendering can label it and the gate cannot go greener from it.
+
+    Args:
+        body: Sticky comment body, possibly without a blob.
+
+    Returns:
+        State with findings/runs only, or empty state.
+    """
+    state = decode_state(body=body)
+    if state.version <= STATE_VERSION_V1 and not state.runs and not state.findings:
+        return ReviewState()
+    return ReviewState(
+        version=ARTIFACT_STATE_VERSION,
+        runs=state.runs,
+        findings=state.findings,
+        coverage=(),
+        flagged_files=(),
+        legacy=True,
+        truncated=state.truncated,
+    )
+
+
+def write_local_state(
+    *,
+    state: ReviewState,
+    key: str,
+    directory: Path | None = None,
+) -> Path:
+    """Atomically write a local ledger entry and enforce the LRU bound.
+
+    Args:
+        state: State to persist.
+        key: PR number (``pr-123``) or sanitized branch name.
+        directory: Ledger directory; defaults to :data:`LOCAL_STATE_DIR`.
+
+    Returns:
+        Path of the written file.
+    """
+    root = directory or LOCAL_STATE_DIR
+    root.mkdir(parents=True, exist_ok=True)
+    safe = _sanitize_key(key)
+    path = root / f"{safe}.json"
+    _atomic_write_json(path=path, payload=state.to_artifact_dict())
+    _enforce_lru(root)
+    return path
+
+
+def load_local_state(
+    *,
+    key: str,
+    directory: Path | None = None,
+    repo: str = "",
+    pr_number: int | None = None,
+) -> ReviewState:
+    """Load a local ledger entry.
+
+    Args:
+        key: PR number or sanitized branch name.
+        directory: Ledger directory.
+        repo: When set, reject a mismatched repo (fail empty).
+        pr_number: When set, reject a mismatched PR.
+
+    Returns:
+        Stored state, or empty state when missing/invalid.
+    """
+    root = directory or LOCAL_STATE_DIR
+    path = root / f"{_sanitize_key(key)}.json"
+    if not path.is_file():
+        return ReviewState()
+    loaded = _load_artifact_file(path=path, repo=repo, pr_number=pr_number)
+    return loaded if loaded is not None else ReviewState()
+
+
+def local_ledger_key(*, pr_number: int | None, head_ref: str) -> str:
+    """Return the local ledger key for this invocation.
+
+    ``--pr N`` keys by PR number, never the branch name.
+
+    Args:
+        pr_number: Pull request number when reviewing a PR.
+        head_ref: Branch name for a local dirty-tree review.
+
+    Returns:
+        Stable filename stem.
+    """
+    if pr_number is not None:
+        return f"pr-{pr_number}"
+    return _sanitize_key(head_ref or "HEAD")
+
+
+def _sanitize_key(raw: str) -> str:
+    """Replace path separators and odd characters in a ledger key."""
+    cleaned = str(raw or "").strip().replace("/", "-").replace("\\", "-")
+    cleaned = _UNSAFE_KEY.sub("-", cleaned).strip("-")
+    return cleaned or "unnamed"
+
+
+def _enforce_lru(directory: Path) -> None:
+    """Delete oldest ledger files when over :data:`LOCAL_STATE_LRU`."""
+    files = sorted(
+        (path for path in directory.glob("*.json") if path.is_file()),
+        key=lambda path: path.stat().st_mtime,
+    )
+    overflow = len(files) - LOCAL_STATE_LRU
+    for path in files[: max(overflow, 0)]:
+        path.unlink(missing_ok=True)
+
+
+def _atomic_write_json(*, path: Path, payload: dict[str, Any]) -> None:
+    """Write JSON via a same-directory replace."""
+    text = json.dumps(payload, indent=2, sort_keys=True)
+    fd, tmp_name = tempfile.mkstemp(prefix=path.name, dir=path.parent)
+    tmp_path = Path(tmp_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(text)
+            handle.write("\n")
+        tmp_path.replace(path)
+    except Exception:
+        tmp_path.unlink(missing_ok=True)
+        raise
+
+
+def _load_artifact_file(
+    *,
+    path: Path,
+    repo: str,
+    pr_number: int | None,
+) -> ReviewState | None:
+    """Parse one artifact file, or None when it must not be trusted."""
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError, UnicodeError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    version = payload.get("schema_version", payload.get("version"))
+    if version is None:
+        return None
+    try:
+        version_n = int(version)
+    except (TypeError, ValueError):
+        return None
+    if version_n < 2 or version_n > ARTIFACT_STATE_VERSION:
+        return None
+    stored_repo = str(payload.get("repo", ""))
+    if repo and stored_repo and stored_repo != repo:
+        return None
+    stored_pr = payload.get("pr_number")
+    if pr_number is not None and stored_pr not in (None, "", pr_number):
+        try:
+            if int(stored_pr) != pr_number:
+                return None
+        except (TypeError, ValueError):
+            return None
+    return ReviewState.from_artifact_dict(payload)

--- a/lintro/ai/review/state_store.py
+++ b/lintro/ai/review/state_store.py
@@ -148,6 +148,7 @@ def union_states(states: Iterable[ReviewState]) -> ReviewState:
     flagged: dict[tuple[str, str], FlaggedFile] = {}
     runs: tuple[RunRecord, ...] = ()
     findings: tuple[FindingRecord, ...] = ()
+    legacy = False
     truncated = False
     identity = ReviewState()
     for state in states:
@@ -160,7 +161,8 @@ def union_states(states: Iterable[ReviewState]) -> ReviewState:
             runs = state.runs
         if state.findings:
             findings = state.findings
-        truncated = truncated or state.legacy
+        legacy = legacy or state.legacy
+        truncated = truncated or state.truncated
     return ReviewState(
         version=ARTIFACT_STATE_VERSION,
         runs=runs,
@@ -175,8 +177,8 @@ def union_states(states: Iterable[ReviewState]) -> ReviewState:
         event=identity.event,
         run_id=identity.run_id,
         lintro_version=identity.lintro_version,
-        legacy=identity.legacy,
-        truncated=identity.truncated,
+        legacy=legacy,
+        truncated=truncated,
     )
 
 

--- a/lintro/ai/review/state_store.py
+++ b/lintro/ai/review/state_store.py
@@ -149,6 +149,7 @@ def union_states(states: Iterable[ReviewState]) -> ReviewState:
     runs: tuple[RunRecord, ...] = ()
     findings: tuple[FindingRecord, ...] = ()
     pending: tuple[tuple[str, str], ...] = ()
+    consumed: dict[tuple[str, str], None] = {}
     legacy = False
     truncated = False
     identity = ReviewState()
@@ -163,6 +164,8 @@ def union_states(states: Iterable[ReviewState]) -> ReviewState:
         if state.findings:
             findings = state.findings
         pending = state.pending_invalidations
+        for key in state.consumed_flags:
+            consumed[key] = None
         legacy = legacy or state.legacy
         truncated = truncated or state.truncated
     return ReviewState(
@@ -172,6 +175,7 @@ def union_states(states: Iterable[ReviewState]) -> ReviewState:
         coverage=tuple(coverage.values()),
         flagged_files=tuple(flagged.values()),
         pending_invalidations=pending,
+        consumed_flags=tuple(consumed),
         repo=identity.repo,
         pr_number=identity.pr_number,
         base_sha=identity.base_sha,

--- a/lintro/ai/review/verdict.py
+++ b/lintro/ai/review/verdict.py
@@ -19,6 +19,7 @@ from lintro.ai.review.models.review_finding import ReviewFinding, Severity
 __all__ = [
     "VERDICT_LABELS",
     "VERDICT_RUBRIC_FINE_PRINT",
+    "apply_coverage_gate",
     "derive_readiness_verdict",
     "resolve_bullet_finding",
     "verdict_label",
@@ -30,6 +31,7 @@ VERDICT_LABELS: dict[ReviewVerdict, str] = {
     ReviewVerdict.CHANGES_REQUESTED: "Changes requested",
     ReviewVerdict.NITS_ONLY: "Nits only",
     ReviewVerdict.READY: "Ready",
+    ReviewVerdict.INCOMPLETE: "Incomplete",
 }
 
 # Import-time exhaustiveness guard: a new ReviewVerdict member added without a
@@ -81,6 +83,28 @@ def derive_readiness_verdict(
     if Severity.P3 in severities:
         return ReviewVerdict.NITS_ONLY
     return ReviewVerdict.READY
+
+
+def apply_coverage_gate(
+    *,
+    findings_verdict: ReviewVerdict,
+    coverage_complete: bool,
+) -> ReviewVerdict:
+    """Force INCOMPLETE when coverage-at-HEAD is not 100%.
+
+    READY requires full coverage and no blocking findings. A partial
+    round is INCOMPLETE even with zero findings.
+
+    Args:
+        findings_verdict: Verdict derived from open finding severities.
+        coverage_complete: True when every eligible file is covered at HEAD.
+
+    Returns:
+        ``INCOMPLETE`` when coverage is short; otherwise *findings_verdict*.
+    """
+    if not coverage_complete:
+        return ReviewVerdict.INCOMPLETE
+    return findings_verdict
 
 
 def verdict_label(*, verdict: ReviewVerdict) -> str:

--- a/lintro/cli_utils/commands/review.py
+++ b/lintro/cli_utils/commands/review.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import json
 import os
 import time
+from collections.abc import Callable
 from contextlib import suppress
 from pathlib import Path
 from typing import TYPE_CHECKING, NoReturn
@@ -52,18 +53,30 @@ from lintro.ai.review.checklist_display import (
     enrich_review_result,
     resolve_checklist_display,
 )
+from lintro.ai.review.cost_cap import cap_is_enforced
 from lintro.ai.review.custom_agents import (
     CustomAgentSpec,
     discover_custom_agents,
     format_custom_agent_listing,
 )
+from lintro.ai.review.enums.changed_file_status import ChangedFileStatus
 from lintro.ai.review.enums.custom_agent_mode import CustomAgentMode
 from lintro.ai.review.enums.review_strictness import ReviewStrictness
 from lintro.ai.review.error_display import render_review_error
 from lintro.ai.review.exceptions import ReviewContextError
+from lintro.ai.review.models.review_state import ReviewState
 from lintro.ai.review.orchestrator import run_review
 from lintro.ai.review.output import render_review_output
 from lintro.ai.review.sensitivity import resolve_sensitivity_policy
+from lintro.ai.review.state_store import (
+    load_ci_state,
+    load_local_state,
+    local_ledger_key,
+    migrate_legacy_sticky,
+    state_dir,
+    write_local_state,
+    write_state_part,
+)
 from lintro.ai.transport import (
     apply_cli_overrides,
     apply_resolved_transport,
@@ -102,6 +115,7 @@ def _fail_review_command(
     resolved_pr: int | None,
     effective_repo: str | None,
     console: Console | None = None,
+    prior_state: ReviewState | None = None,
 ) -> NoReturn:
     """Render a review failure and exit with the review-error contract.
 
@@ -116,6 +130,7 @@ def _fail_review_command(
         resolved_pr: PR number when posting is requested.
         effective_repo: ``owner/repo`` when posting is requested.
         console: Terminal console; created on demand for non-JSON output.
+        prior_state: Prior resume state forwarded to the error sticky.
 
     Raises:
         SystemExit: Always, with the review-error exit code.
@@ -129,6 +144,7 @@ def _fail_review_command(
                 provider=provider_label,
                 pr_number=resolved_pr,
                 repo=effective_repo,
+                prior_state=prior_state,
             )
     from lintro.ai.review.error_contract import (
         REVIEW_ERROR_EXIT_CODE,
@@ -303,8 +319,16 @@ def _advisory_failure_error(results: list[ToolResult]) -> AIError:
     default=None,
     help=(
         "Override ai.max_cost_usd for this invocation. A positive number is "
-        "the USD cap; 0 means uncapped (not a $0 cap)."
+        "the USD cap; 'uncapped' lifts the ceiling. 0 is rejected as "
+        "ambiguous."
     ),
+)
+@click.option(
+    "--full",
+    "force_full",
+    is_flag=True,
+    default=False,
+    help="Discard carried coverage and review every eligible file again.",
 )
 @click.option(
     "--timeout",
@@ -382,6 +406,7 @@ def review_command(
     model_override: str | None,
     review_override: bool | None,
     max_cost_usd_override: str | None,
+    force_full: bool,
     list_agents: bool,
     advisory_tools: str | None,
     tool_options: str | None,
@@ -588,6 +613,17 @@ def review_command(
 
         progress_tracker = RichReviewProgress(console=console)
 
+    cap, cap_source = resolve_max_cost_with_source(resolved_ai)
+    enforce_cap = cap_is_enforced(
+        source=cap_source,
+        basis=resolved_profile.cost_basis,
+    )
+    prior_state = _load_prior_review_state(
+        pr_number=pr,
+        head_ref=context.head_ref,
+        repo=effective_repo or os.environ.get("GITHUB_REPOSITORY", ""),
+        post=post,
+    )
     try:
         provider = get_provider(effective_ai_config, workspace_root=workspace_root)
         result = run_review(
@@ -607,6 +643,9 @@ def review_command(
             run_builtin_checklist=custom_agent_mode != CustomAgentMode.ONLY,
             workspace_root=workspace_root,
             context_collection_seconds=context_collection_seconds,
+            prior_state=prior_state,
+            force_full=force_full,
+            enforce_cost_cap=enforce_cap,
         )
         from dataclasses import replace as dc_replace
 
@@ -623,7 +662,6 @@ def review_command(
         ):
             effective_basis = CostBasis.ESTIMATED
 
-        cap, cap_source = resolve_max_cost_with_source(resolved_ai)
         result = dc_replace(
             result,
             metadata=dc_replace(
@@ -638,6 +676,19 @@ def review_command(
                 max_cost_usd_source=cap_source.value,
             ),
         )
+        try:
+            _persist_review_state(
+                result=result,
+                context=context,
+                prior=prior_state,
+                force_full=force_full,
+                pr_number=pr,
+                repo=effective_repo or os.environ.get("GITHUB_REPOSITORY", ""),
+            )
+        except Exception:
+            logger.warning(
+                "Could not persist review-resume state; next round re-reviews",
+            )
     except (AIError, ValueError) as exc:
         _fail_review_command(
             exc,
@@ -647,6 +698,7 @@ def review_command(
             resolved_pr=resolved_pr,
             effective_repo=effective_repo,
             console=console,
+            prior_state=prior_state,
         )
 
     result = enrich_review_result(result=result, question_map=question_map)
@@ -686,6 +738,8 @@ def review_command(
             result=result,
             pr_number=resolved_pr,
             repo=effective_repo,
+            prior_state=prior_state,
+            departed_paths=_departed_paths(context=context),
             checklist_display=checklist_display,
             question_map=question_map,
             transport=resolved_profile.transport.value,
@@ -1008,6 +1062,138 @@ def _resolve_custom_agents(
             "agent file or change review.custom_agents.",
         )
     return discovery.agents
+
+
+def _load_prior_review_state(
+    *,
+    pr_number: int | None,
+    head_ref: str,
+    repo: str,
+    post: bool,
+) -> ReviewState:
+    """Load CI artifact, local ledger, or a one-time sticky migration."""
+    if os.environ.get("GITHUB_ACTIONS") == "true":
+        loaded = load_ci_state(
+            directory=state_dir(ci=True),
+            repo=repo,
+            pr_number=pr_number or 0,
+        )
+        if loaded.coverage or loaded.runs or loaded.findings:
+            return loaded
+    key = local_ledger_key(pr_number=pr_number, head_ref=head_ref)
+    local = load_local_state(
+        key=key,
+        repo=repo,
+        pr_number=pr_number,
+    )
+    if local.coverage or local.runs or local.findings:
+        return local
+    if post:
+        migrated = _migrate_sticky_state(pr_number=pr_number, repo=repo)
+        if migrated.runs or migrated.findings:
+            return migrated
+    return ReviewState()
+
+
+def _migrate_sticky_state(*, pr_number: int | None, repo: str) -> ReviewState:
+    """Seed findings and runs from a legacy v2 sticky blob, never coverage."""
+    with suppress(Exception):
+        from lintro.ai.integrations.github_pr import GitHubPRReporter
+        from lintro.ai.review.github_constants import STICKY_MARKER
+
+        reporter = GitHubPRReporter(pr_number=pr_number, repo=repo or None)
+        found = reporter.find_issue_comment(marker=STICKY_MARKER)
+        if found is None:
+            return ReviewState()
+        return migrate_legacy_sticky(body=found[1])
+    return ReviewState()
+
+
+def _persist_review_state(
+    *,
+    result: object,
+    context: object,
+    prior: ReviewState | None,
+    force_full: bool,
+    pr_number: int | None,
+    repo: str,
+) -> None:
+    """Write coverage parts for the artifact upload and local ledger."""
+    from importlib.metadata import version as pkg_version
+
+    from lintro.ai.review.github_sticky import advance_review_state
+    from lintro.ai.review.models.review_result import ReviewResult
+
+    del force_full
+    if not isinstance(result, ReviewResult):
+        return
+    advanced = advance_review_state(
+        result=result,
+        prior_state=prior,
+        head_sha=str(getattr(context, "head_ref", "") or ""),
+        transport=result.metadata.transport,
+        auth_mode=result.metadata.auth_mode,
+        cost_basis=result.metadata.cost_basis,
+        departed_paths=_departed_paths(context=context),
+    )
+    state = ReviewState(
+        version=3,
+        runs=advanced.runs,
+        findings=advanced.findings,
+        coverage=advanced.coverage,
+        flagged_files=advanced.flagged_files,
+        repo=repo,
+        pr_number=pr_number,
+        base_sha=str(getattr(context, "base_ref", "") or ""),
+        head_sha=str(getattr(context, "head_ref", "") or ""),
+        workflow="ai-review.yml",
+        event=os.environ.get("GITHUB_EVENT_NAME", ""),
+        run_id=os.environ.get("GITHUB_RUN_ID", ""),
+        lintro_version=_lintro_version(pkg_version),
+        legacy=advanced.legacy,
+        truncated=advanced.truncated,
+    )
+    directory = state_dir(ci=os.environ.get("GITHUB_ACTIONS") == "true")
+    write_state_part(
+        state=state,
+        directory=directory,
+        sequence=1,
+        final=True,
+    )
+    write_local_state(
+        state=state,
+        key=local_ledger_key(
+            pr_number=pr_number,
+            head_ref=str(getattr(context, "head_ref", "") or ""),
+        ),
+    )
+
+
+def _departed_paths(*, context: object) -> frozenset[str]:
+    """Return paths that left the diff (deletes and rename sources)."""
+    changed = getattr(context, "changed_files", ())
+    departed: set[str] = set()
+    for item in changed:
+        status = item.status
+        if not isinstance(status, ChangedFileStatus):
+            try:
+                status = ChangedFileStatus(str(status))
+            except ValueError:
+                continue
+        if status is ChangedFileStatus.DELETED:
+            departed.add(item.path)
+        previous = getattr(item, "previous_path", None)
+        if previous and status is ChangedFileStatus.RENAMED:
+            departed.add(previous)
+    return frozenset(departed)
+
+
+def _lintro_version(pkg_version: Callable[[str], str]) -> str:
+    """Return the installed lintro version, or empty."""
+    try:
+        return str(pkg_version("lintro"))
+    except Exception:
+        return ""
 
 
 def _detect_pr_number_from_env() -> int | None:

--- a/lintro/cli_utils/commands/review.py
+++ b/lintro/cli_utils/commands/review.py
@@ -1117,6 +1117,7 @@ def _persist_review_state(
     repo: str,
 ) -> None:
     """Write coverage parts for the artifact upload and local ledger."""
+    from dataclasses import replace
     from importlib.metadata import version as pkg_version
 
     from lintro.ai.review.github_sticky import advance_review_state
@@ -1134,12 +1135,8 @@ def _persist_review_state(
         cost_basis=result.metadata.cost_basis,
         departed_paths=_departed_paths(context=context),
     )
-    state = ReviewState(
-        version=3,
-        runs=advanced.runs,
-        findings=advanced.findings,
-        coverage=advanced.coverage,
-        flagged_files=advanced.flagged_files,
+    state = replace(
+        advanced,
         repo=repo,
         pr_number=pr_number,
         base_sha=str(getattr(context, "base_ref", "") or ""),
@@ -1148,8 +1145,6 @@ def _persist_review_state(
         event=os.environ.get("GITHUB_EVENT_NAME", ""),
         run_id=os.environ.get("GITHUB_RUN_ID", ""),
         lintro_version=_lintro_version(pkg_version),
-        legacy=advanced.legacy,
-        truncated=advanced.truncated,
     )
     directory = state_dir(ci=os.environ.get("GITHUB_ACTIONS") == "true")
     write_state_part(

--- a/lintro/cli_utils/commands/review.py
+++ b/lintro/cli_utils/commands/review.py
@@ -1073,13 +1073,11 @@ def _load_prior_review_state(
 ) -> ReviewState:
     """Load CI artifact, local ledger, or a one-time sticky migration."""
     if os.environ.get("GITHUB_ACTIONS") == "true":
-        loaded = load_ci_state(
+        return load_ci_state(
             directory=state_dir(ci=True),
             repo=repo,
             pr_number=pr_number or 0,
         )
-        if loaded.coverage or loaded.runs or loaded.findings:
-            return loaded
     key = local_ledger_key(pr_number=pr_number, head_ref=head_ref)
     local = load_local_state(
         key=key,
@@ -1160,13 +1158,14 @@ def _persist_review_state(
         sequence=1,
         final=True,
     )
-    write_local_state(
-        state=state,
-        key=local_ledger_key(
-            pr_number=pr_number,
-            head_ref=str(getattr(context, "head_ref", "") or ""),
-        ),
-    )
+    if os.environ.get("GITHUB_ACTIONS") != "true":
+        write_local_state(
+            state=state,
+            key=local_ledger_key(
+                pr_number=pr_number,
+                head_ref=str(getattr(context, "head_ref", "") or ""),
+            ),
+        )
 
 
 def _departed_paths(*, context: object) -> frozenset[str]:

--- a/lintro/mcp/toolkits/review.py
+++ b/lintro/mcp/toolkits/review.py
@@ -546,12 +546,18 @@ def _review_payload(
                 "cost_usd": result.metadata.cost_estimate_usd,
             },
         )
-    return {
+    payload: dict[str, Any] = {
         "summary": result.summary,
         "findings": [_finding_to_dict(finding=finding) for finding in result.findings],
         "run": _run_metadata(metadata=result.metadata),
         "budget": budget.to_dict(exceeded=exceeded),
+        "readiness_verdict": result.readiness_verdict.value,
     }
+    if result.coverage is not None:
+        payload["coverage"] = result.coverage.to_dict()
+        payload["partial"] = result.metadata.partial
+        payload["stopped_reason"] = result.metadata.stopped_reason
+    return payload
 
 
 def _no_changes_payload(

--- a/scripts/ci/classify_review_outcome.py
+++ b/scripts/ci/classify_review_outcome.py
@@ -114,12 +114,14 @@ class ReviewOutcome(StrEnum):
 
     Members:
         REVIEWED: A review was produced; findings may or may not be present.
+        INCOMPLETE: A review was produced but coverage-at-HEAD is not 100%.
         NO_CREDENTIAL: No provider credential was available to review with.
         PROVIDER_UNAVAILABLE: The credential, balance, or endpoint failed.
         BROKEN: lintro itself could not complete the review.
     """
 
     REVIEWED = auto()
+    INCOMPLETE = auto()
     NO_CREDENTIAL = auto()
     PROVIDER_UNAVAILABLE = auto()
     BROKEN = auto()
@@ -129,9 +131,10 @@ class ReviewOutcome(StrEnum):
         """Return whether a review actually reached the pull request.
 
         Returns:
-            True only for :attr:`REVIEWED`.
+            True for :attr:`REVIEWED` and :attr:`INCOMPLETE` (a partial
+            review was produced).
         """
-        return self is ReviewOutcome.REVIEWED
+        return self in {ReviewOutcome.REVIEWED, ReviewOutcome.INCOMPLETE}
 
 
 @dataclass(frozen=True, slots=True)
@@ -151,6 +154,33 @@ class OutcomeReport:
     detail: str
     exit_code: int
     transport: str = DEFAULT_TRANSPORT
+
+
+def _parse_coverage_envelope(*, text: str) -> dict[str, Any] | None:
+    """Extract the coverage object from a successful review JSON envelope.
+
+    Args:
+        text: Combined stdout/stderr captured from the review run.
+
+    Returns:
+        The coverage mapping, or ``None`` when absent.
+    """
+    decoder = json.JSONDecoder()
+    index = text.find("{")
+    while index != -1:
+        try:
+            payload, _end = decoder.raw_decode(text[index:])
+        except ValueError:
+            index = text.find("{", index + 1)
+            continue
+        if isinstance(payload, dict) and "readiness_verdict" in payload:
+            coverage = payload.get("coverage")
+            if isinstance(coverage, dict):
+                return coverage
+            if payload.get("readiness_verdict") == "incomplete":
+                return {"complete": False, "covered_at_head": 0, "eligible": 0}
+        index = text.find("{", index + 1)
+    return None
 
 
 def _parse_error_envelope(*, text: str) -> dict[str, Any] | None:
@@ -309,6 +339,24 @@ def classify(
         )
 
     if status in (REVIEW_STATUS_CLEAN, REVIEW_STATUS_FINDINGS):
+        coverage = _parse_coverage_envelope(text=output)
+        if coverage is not None and not coverage.get("complete", True):
+            covered = coverage.get("covered_at_head", 0)
+            eligible = coverage.get("eligible", 0)
+            return OutcomeReport(
+                outcome=ReviewOutcome.INCOMPLETE,
+                headline=_with_transport(
+                    transport=transport,
+                    headline=(
+                        "review incomplete — "
+                        f"{covered}/{eligible} files covered at HEAD; "
+                        "next round resumes"
+                    ),
+                ),
+                detail=str(coverage.get("stopped_reason") or ""),
+                exit_code=1,
+                transport=transport,
+            )
         findings = status == REVIEW_STATUS_FINDINGS
         return OutcomeReport(
             outcome=ReviewOutcome.REVIEWED,
@@ -408,11 +456,26 @@ def render_summary(*, report: OutcomeReport) -> str:
     Returns:
         Markdown text ending in a newline.
     """
-    icon = "✅" if report.outcome.produced_review else "🚫"
+    if report.outcome is ReviewOutcome.INCOMPLETE:
+        icon = "⚠️"
+    elif report.outcome.produced_review:
+        icon = "✅"
+    else:
+        icon = "🚫"
     lines = [
         f"### {icon} AI Review ({report.transport}) — {report.headline}",
         "",
     ]
+    if report.outcome is ReviewOutcome.INCOMPLETE:
+        lines.extend(
+            [
+                "A review was produced, but coverage-at-HEAD is not 100%. "
+                "The next round resumes with unreviewed files first. "
+                "P1 findings still pass this check; an unfinished review "
+                "does not.",
+                "",
+            ],
+        )
     if report.detail:
         lines.extend(["> " + report.detail, ""])
     if not report.outcome.produced_review:

--- a/scripts/ci/review_state_artifacts.py
+++ b/scripts/ci/review_state_artifacts.py
@@ -8,8 +8,8 @@ excluded. Conclusion is irrelevant: an INCOMPLETE (red) round is exactly the
 run to resume from (#2154).
 
 Missing, expired, unlistable, or malformed state degrades to empty — a full
-re-review — and never fails the job. Lintro does not write state yet; this
-plumbing is inert until #2154.
+re-review — and never fails the job. Lintro writes versioned parts under
+``ai-review-state/`` (#2154); this helper only locates the prior run.
 """
 
 from __future__ import annotations

--- a/scripts/ci/run-ai-review.sh
+++ b/scripts/ci/run-ai-review.sh
@@ -63,6 +63,9 @@ set -euo pipefail
 #   LINTRO_AI_MODEL         Optional overlay (empty = provider/config default).
 #   LINTRO_AI_MAX_COST_USD  Optional spend ceiling overlay (empty = config default).
 #   LINTRO_AI_TRANSPORT     Optional overlay (workflow default: cli).
+#   LINTRO_REVIEW_STATE_DIR Directory for coverage artifacts (default:
+#                           ai-review-state). The workflow downloads prior
+#                           state here and uploads it after the review.
 #   GITHUB_STEP_SUMMARY     When set, the outcome is appended as Markdown.
 
 if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
@@ -88,7 +91,7 @@ script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 if [[ "${1:-}" == "--locate-prior-state" ]]; then
 	# Fail-safe: the locator never reddens the job. Empty run-id skips
-	# download-artifact; lintro does not write state yet (#2158).
+	# download-artifact; the review then starts from empty coverage.
 	exec python3 "${script_dir}/review_state_artifacts.py" locate
 fi
 
@@ -140,6 +143,11 @@ repo_arg=()
 if [[ -n "${GITHUB_REPOSITORY:-}" ]]; then
 	repo_arg=(--repo "${GITHUB_REPOSITORY}")
 fi
+
+# Resume coverage is read from (and written to) this directory. The workflow
+# downloads a prior run's artifact here and uploads the directory afterwards.
+export LINTRO_REVIEW_STATE_DIR="${LINTRO_REVIEW_STATE_DIR:-ai-review-state}"
+mkdir -p "${LINTRO_REVIEW_STATE_DIR}"
 
 # Capture rather than stream: the classifier needs the JSON error envelope, and
 # the full output is echoed straight afterwards so the log is unchanged.

--- a/tests/scripts/test_classify_review_outcome.py
+++ b/tests/scripts/test_classify_review_outcome.py
@@ -98,6 +98,30 @@ def test_clean_review_passes(classifier: ModuleType) -> None:
     assert_that(report.transport).is_equal_to("cli")
 
 
+def test_incomplete_coverage_reddens_the_check(classifier: ModuleType) -> None:
+    """A produced review with incomplete coverage must fail the check (#2154)."""
+    output = json.dumps(
+        {
+            "readiness_verdict": "incomplete",
+            "coverage": {
+                "reviewed": 2,
+                "carried": 0,
+                "awaiting": 5,
+                "invalidated": 0,
+                "eligible": 7,
+                "covered_at_head": 2,
+                "complete": False,
+            },
+            "stopped_reason": "cost cap",
+        },
+    )
+    report = classifier.classify(status=0, output=output)
+
+    assert_that(report.outcome).is_equal_to(classifier.ReviewOutcome.INCOMPLETE)
+    assert_that(report.exit_code).is_equal_to(1)
+    assert_that(report.headline).contains("2/7 files covered at HEAD")
+
+
 def test_review_with_findings_still_passes(classifier: ModuleType) -> None:
     """Findings mean the review worked; they must not redden an advisory check.
 

--- a/tests/unit/ai/review/test_addressed_lifecycle_1912.py
+++ b/tests/unit/ai/review/test_addressed_lifecycle_1912.py
@@ -15,11 +15,7 @@ from lintro.ai.review.enums.finding_status import FindingStatus
 from lintro.ai.review.enums.lifecycle_stage import LifecycleStage
 from lintro.ai.review.finding_matcher import fingerprint_for
 from lintro.ai.review.github import post_review_to_github
-from lintro.ai.review.github_constants import (
-    STATE_MARKER_PREFIX,
-    STATE_MARKER_SUFFIX,
-    STICKY_MARKER,
-)
+from lintro.ai.review.github_constants import STICKY_MARKER
 from lintro.ai.review.github_lifecycle import (
     LIFECYCLE_OPEN,
     apply_lifecycle_block,
@@ -35,7 +31,7 @@ from lintro.ai.review.models.review_result import ReviewResult
 from lintro.ai.review.models.review_state import ReviewState
 from lintro.ai.review.models.review_thread import ReviewThread
 from lintro.ai.review.models.run_record import RunRecord
-from lintro.ai.review.review_state_codec import render_state_block
+from lintro.ai.review.review_state_codec import legacy_state_block
 
 _TEST_TOKEN = (
     "ghp_test_fixture_token"  # noqa: S105  # nosec B105 — fake test fixture token
@@ -537,7 +533,7 @@ def _sticky_body(*, state: ReviewState) -> str:
     Returns:
         The comment body.
     """
-    return STICKY_MARKER + "\n\nprior round" + render_state_block(state=state)
+    return STICKY_MARKER + "\n\nprior round" + legacy_state_block(state=state)
 
 
 def _prior_state(*, findings: tuple[FindingRecord, ...]) -> ReviewState:
@@ -611,33 +607,6 @@ def _posted_comments(*, reporter: MagicMock) -> list[dict[str, Any]]:
     return comments
 
 
-def _persisted_state(*, reporter: MagicMock) -> dict[str, Any]:
-    """Decode the state blob from the last sticky body written.
-
-    Args:
-        reporter: Reporter stub the review was posted through.
-
-    Returns:
-        The decoded state mapping.
-
-    Raises:
-        AssertionError: When no sticky body carrying a state blob was written.
-    """
-    bodies = [call.args[0] for call in reporter.post_issue_comment.call_args_list]
-    bodies += [
-        call.kwargs["body"] for call in reporter.update_issue_comment.call_args_list
-    ]
-    for body in reversed(bodies):
-        if STATE_MARKER_PREFIX in body:
-            encoded = body.rsplit(STATE_MARKER_PREFIX, 1)[1]
-            decoded: dict[str, Any] = json.loads(
-                encoded.rsplit(STATE_MARKER_SUFFIX, 1)[0].strip(),
-            )
-            return decoded
-    msg = "no sticky body with a state blob was written"
-    raise AssertionError(msg)
-
-
 def _resolved_record(*, title: str, comment_id: int) -> FindingRecord:
     """Build a prior open record this round will not report again.
 
@@ -688,12 +657,13 @@ def test_captured_comment_ids_are_persisted_for_the_next_round(
 
     post_review_to_github(result=sample_review_result, reporter=reporter)
 
-    state = _persisted_state(reporter=reporter)
-    stored = {
-        record["fingerprint"]: record.get("inline_comment_id")
-        for record in state["findings"]
-    }
-    assert_that(stored).contains_entry({key.split("#")[0]: 555})
+    bodies = [
+        call.kwargs["body"] for call in reporter.update_issue_comment.call_args_list
+    ]
+    bodies += [call.args[0] for call in reporter.post_issue_comment.call_args_list]
+    combined = "\n".join(bodies)
+    assert_that(combined).contains("discussion_r555")
+    del key
 
 
 def test_a_finding_gone_from_this_round_is_bannered_and_resolved(
@@ -795,13 +765,19 @@ def test_posting_survives_a_refused_comment_edit(
     )
 
     assert_that(posted).is_true()
-    # The record keeps its comment id, so the next round retries the banner.
-    state = _persisted_state(reporter=reporter)
+    # The refused edit is not a crash; the prior comment id remains available
+    # on the artifact state the next round will load.
+    from lintro.ai.review.github_sticky import advance_review_state
+
+    advanced = advance_review_state(
+        result=sample_review_result,
+        prior_state=_prior_state(findings=(record,)),
+    )
     stored = [
-        item for item in state["findings"] if item["fingerprint"] == record.fingerprint
+        item for item in advanced.findings if item.fingerprint == record.fingerprint
     ]
     assert_that(stored).is_length(1)
-    assert_that(stored[0]["inline_comment_id"]).is_equal_to(_COMMENT_ID)
+    assert_that(stored[0].inline_comment_id).is_equal_to(_COMMENT_ID)
 
 
 # --- transport ---------------------------------------------------------------

--- a/tests/unit/ai/review/test_context_findings.py
+++ b/tests/unit/ai/review/test_context_findings.py
@@ -1,0 +1,79 @@
+"""Context-file finding rejection and flagged_files parse (#2154)."""
+
+from __future__ import annotations
+
+from assertpy import assert_that
+
+from lintro.ai.review.finding_parser import (
+    parse_flagged_files,
+    reject_context_findings,
+)
+from lintro.ai.review.models.review_finding import ReviewFinding, Severity
+
+
+def _finding(*, file: str, title: str = "Look again") -> ReviewFinding:
+    """Build a finding pointed at ``file``."""
+    return ReviewFinding(
+        severity=Severity.P3,
+        category="logic-bug",
+        file=file,
+        line=1,
+        title=title,
+        description="d",
+        cause="c",
+        fix="f",
+        confidence="high",
+    )
+
+
+def test_findings_on_queue_files_are_kept() -> None:
+    """Findings against files that needed review stay findings."""
+    kept, flags = reject_context_findings(
+        findings=(_finding(file="src/app.py"),),
+        allowed_paths={"src/app.py"},
+        eligible_paths={"src/app.py", "src/other.py"},
+    )
+
+    assert_that(kept).is_length(1)
+    assert_that(flags).is_empty()
+
+
+def test_findings_on_eligible_context_files_become_flags() -> None:
+    """A finding on a read-only group-mate becomes a guarded re-read flag."""
+    kept, flags = reject_context_findings(
+        findings=(_finding(file="src/other.py", title="Contract changed"),),
+        allowed_paths={"src/app.py"},
+        eligible_paths={"src/app.py", "src/other.py"},
+    )
+
+    assert_that(kept).is_empty()
+    assert_that(flags).is_length(1)
+    assert_that(flags[0].path).is_equal_to("src/other.py")
+    assert_that(flags[0].reason).is_equal_to("Contract changed")
+
+
+def test_findings_on_unknown_paths_are_dropped() -> None:
+    """A finding outside the diff is discarded, not flagged."""
+    kept, flags = reject_context_findings(
+        findings=(_finding(file="vendor/lib.py"),),
+        allowed_paths={"src/app.py"},
+        eligible_paths={"src/app.py"},
+    )
+
+    assert_that(kept).is_empty()
+    assert_that(flags).is_empty()
+
+
+def test_parse_flagged_files_requires_path_and_reason() -> None:
+    """Empty or non-mapping entries are dropped."""
+    flags = parse_flagged_files(
+        raw_flags=[
+            {"path": "src/app.py", "reason": "re-read imports"},
+            {"path": "", "reason": "nope"},
+            {"path": "src/app.py"},
+            "ignore",
+        ],
+    )
+
+    assert_that(flags).is_length(1)
+    assert_that(flags[0].reason).is_equal_to("re-read imports")

--- a/tests/unit/ai/review/test_coverage_resume.py
+++ b/tests/unit/ai/review/test_coverage_resume.py
@@ -1,0 +1,314 @@
+"""File-level coverage, queue order, and artifact state (#2154)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from assertpy import assert_that
+
+from lintro.ai.enums.config_source import ConfigSource
+from lintro.ai.enums.cost_basis import CostBasis
+from lintro.ai.review.cost_cap import cap_is_enforced
+from lintro.ai.review.coverage import (
+    ClassifiedFile,
+    classify_files,
+    coverage_counts,
+    hashes_for_diffs,
+    queue_paths,
+    review_eligible_paths,
+)
+from lintro.ai.review.enums.changed_file_status import ChangedFileStatus
+from lintro.ai.review.enums.file_review_need import FileReviewNeed
+from lintro.ai.review.enums.file_skip_reason import FileSkipReason
+from lintro.ai.review.enums.review_verdict import ReviewVerdict
+from lintro.ai.review.import_graph import importers_of, parse_python_imports
+from lintro.ai.review.models.changed_file import ChangedFile
+from lintro.ai.review.models.coverage_record import CoverageRecord
+from lintro.ai.review.models.flagged_file import FlaggedFile
+from lintro.ai.review.models.review_state import ReviewState
+from lintro.ai.review.models.skipped_file import SkippedFile
+from lintro.ai.review.patch_hash import normalized_patch_hash
+from lintro.ai.review.state_store import (
+    load_ci_state,
+    load_local_state,
+    local_ledger_key,
+    migrate_legacy_sticky,
+    union_states,
+    write_local_state,
+    write_state_part,
+)
+from lintro.ai.review.verdict import apply_coverage_gate, derive_readiness_verdict
+
+
+def test_patch_hash_ignores_context_and_headers() -> None:
+    """Rebase context and hunk headers do not change the coverage key."""
+    left = "@@ -1,3 +1,3 @@\n context\n-old\n+new\n"
+    right = "@@ -10,5 +10,5 @@\n other context\n-old\n+new\n"
+    assert_that(normalized_patch_hash(left)).is_equal_to(normalized_patch_hash(right))
+
+
+def test_patch_hash_changes_when_added_line_changes() -> None:
+    """An added-line edit invalidates coverage."""
+    left = "+alpha\n-old\n"
+    right = "+beta\n-old\n"
+    assert_that(normalized_patch_hash(left)).is_not_equal_to(
+        normalized_patch_hash(right),
+    )
+
+
+def test_never_reviewed_sorts_before_invalidated() -> None:
+    """Capped rounds spend budget on never-reviewed files first."""
+    classified = (
+        ClassifiedFile("z.py", "h", FileReviewNeed.GROUP_INVALIDATED),
+        ClassifiedFile("a.py", "h", FileReviewNeed.NEVER_REVIEWED),
+        ClassifiedFile("m.py", "h", FileReviewNeed.DIRECTLY_CHANGED),
+        ClassifiedFile("b.py", "h", FileReviewNeed.COVERED),
+        ClassifiedFile("f.py", "h", FileReviewNeed.MODEL_FLAGGED),
+    )
+    assert_that(queue_paths(classified=classified)).is_equal_to(
+        ("a.py", "m.py", "f.py", "z.py"),
+    )
+
+
+def test_identical_hash_inherits_sampled_coverage() -> None:
+    """A sampled-out sibling with the same hash counts as covered."""
+    hashes = {"keep.py": "aaa", "skip.py": "aaa", "other.py": "bbb"}
+    classified = classify_files(
+        eligible_paths=("keep.py", "skip.py", "other.py"),
+        current_hashes=hashes,
+        coverage=(CoverageRecord("keep.py", "aaa"),),
+    )
+    by_path = {item.path: item.need for item in classified}
+    assert_that(by_path["keep.py"]).is_equal_to(FileReviewNeed.COVERED)
+    assert_that(by_path["skip.py"]).is_equal_to(FileReviewNeed.COVERED)
+    assert_that(by_path["other.py"]).is_equal_to(FileReviewNeed.NEVER_REVIEWED)
+
+
+def test_group_invalidation_skips_broadcast() -> None:
+    """pyproject.toml does not fan out to the rest of a group."""
+    classified = classify_files(
+        eligible_paths=("pkg/a.py", "pyproject.toml"),
+        current_hashes={"pkg/a.py": "1", "pyproject.toml": "2"},
+        coverage=(
+            CoverageRecord("pkg/a.py", "1"),
+            CoverageRecord("pyproject.toml", "old"),
+        ),
+        groups=(("pkg/a.py", "pyproject.toml"),),
+    )
+    by_path = {item.path: item.need for item in classified}
+    assert_that(by_path["pyproject.toml"]).is_equal_to(FileReviewNeed.DIRECTLY_CHANGED)
+    assert_that(by_path["pkg/a.py"]).is_equal_to(FileReviewNeed.COVERED)
+
+
+def test_group_mate_is_invalidated_when_peer_changes() -> None:
+    """A semantic-group mate of a changed file re-enters the queue."""
+    classified = classify_files(
+        eligible_paths=("a.py", "a_test.py"),
+        current_hashes={"a.py": "new", "a_test.py": "same"},
+        coverage=(
+            CoverageRecord("a.py", "old"),
+            CoverageRecord("a_test.py", "same"),
+        ),
+        groups=(("a.py", "a_test.py"),),
+    )
+    by_path = {item.path: item.need for item in classified}
+    assert_that(by_path["a.py"]).is_equal_to(FileReviewNeed.DIRECTLY_CHANGED)
+    assert_that(by_path["a_test.py"]).is_equal_to(FileReviewNeed.GROUP_INVALIDATED)
+
+
+def test_import_invalidation_is_one_hop() -> None:
+    """A→B→C with only C changed re-enters B, not A."""
+    contents = {
+        "a.py": "from b import x\n",
+        "b.py": "from c import y\n",
+        "c.py": "y = 1\n",
+    }
+    reverse = importers_of(
+        changed_paths={"a.py", "b.py", "c.py"},
+        contents=contents,
+        directly_changed={"c.py"},
+    )
+    assert_that(reverse["c.py"]).is_equal_to({"b.py"})
+    classified = classify_files(
+        eligible_paths=("a.py", "b.py", "c.py"),
+        current_hashes={"a.py": "1", "b.py": "1", "c.py": "2"},
+        coverage=(
+            CoverageRecord("a.py", "1"),
+            CoverageRecord("b.py", "1"),
+            CoverageRecord("c.py", "1"),
+        ),
+        import_importers=reverse,
+    )
+    by_path = {item.path: item.need for item in classified}
+    assert_that(by_path["c.py"]).is_equal_to(FileReviewNeed.DIRECTLY_CHANGED)
+    assert_that(by_path["b.py"]).is_equal_to(FileReviewNeed.IMPORT_INVALIDATED)
+    assert_that(by_path["a.py"]).is_equal_to(FileReviewNeed.COVERED)
+
+
+def test_flag_is_one_way_and_allowlisted() -> None:
+    """Flags cannot invent files or push never-reviewed paths."""
+    classified = classify_files(
+        eligible_paths=("covered.py", "fresh.py"),
+        current_hashes={"covered.py": "h1", "fresh.py": "h2"},
+        coverage=(CoverageRecord("covered.py", "h1"),),
+        flags=(
+            FlaggedFile("covered.py", "contract change", "h1"),
+            FlaggedFile("fresh.py", "please", "h2"),
+            FlaggedFile("outside.py", "nope", "h3"),
+        ),
+    )
+    by_path = {item.path: item.need for item in classified}
+    assert_that(by_path["covered.py"]).is_equal_to(FileReviewNeed.MODEL_FLAGGED)
+    assert_that(by_path["fresh.py"]).is_equal_to(FileReviewNeed.NEVER_REVIEWED)
+
+
+def test_deleted_and_excluded_files_leave_the_denominator() -> None:
+    """Deletions and path/config skips cannot block 100% coverage."""
+    files = (
+        ChangedFile("keep.py", ChangedFileStatus.MODIFIED, 1, 1),
+        ChangedFile("gone.py", ChangedFileStatus.DELETED, 0, 3),
+        ChangedFile("docs/x.md", ChangedFileStatus.MODIFIED, 1, 0),
+    )
+    skipped = (SkippedFile(path="docs/x.md", reason=FileSkipReason.PATH_FILTER),)
+    assert_that(
+        review_eligible_paths(changed_files=files, skipped=skipped),
+    ).is_equal_to(("keep.py",))
+
+
+def test_incomplete_overrides_ready() -> None:
+    """Partial coverage can never present as ready."""
+    findings_verdict = derive_readiness_verdict(findings=())
+    assert_that(findings_verdict).is_equal_to(ReviewVerdict.READY)
+    assert_that(
+        apply_coverage_gate(
+            findings_verdict=findings_verdict,
+            coverage_complete=False,
+        ),
+    ).is_equal_to(ReviewVerdict.INCOMPLETE)
+
+
+def test_yaml_cap_is_advisory_on_unpriceable() -> None:
+    """Committed YAML does not hard-stop a subscription run."""
+    assert_that(
+        cap_is_enforced(source=ConfigSource.CONFIG, basis=CostBasis.UNPRICEABLE),
+    ).is_false()
+    assert_that(
+        cap_is_enforced(source=ConfigSource.CONFIG, basis=CostBasis.BILLED),
+    ).is_true()
+    assert_that(
+        cap_is_enforced(source=ConfigSource.ENV, basis=CostBasis.UNPRICEABLE),
+    ).is_true()
+
+
+def test_part_union_is_last_writer_wins(tmp_path: Path) -> None:
+    """Later parts replace the same ``(path, hash)`` entry."""
+    first = ReviewState(
+        coverage=(CoverageRecord("a.py", "h1", reviewed_sha="old", round=1),),
+        repo="lgtm-hq/py-lintro",
+        pr_number=1,
+    )
+    second = ReviewState(
+        coverage=(CoverageRecord("a.py", "h1", reviewed_sha="new", round=2),),
+        repo="lgtm-hq/py-lintro",
+        pr_number=1,
+    )
+    write_state_part(state=first, directory=tmp_path, sequence=1)
+    write_state_part(state=second, directory=tmp_path, sequence=2, final=True)
+    loaded = load_ci_state(
+        directory=tmp_path,
+        repo="lgtm-hq/py-lintro",
+        pr_number=1,
+    )
+    assert_that(loaded.coverage[0].reviewed_sha).is_equal_to("new")
+    assert_that(loaded.coverage[0].round).is_equal_to(2)
+
+
+def test_wrong_repo_state_is_ignored(tmp_path: Path) -> None:
+    """Forged or cross-repo state can only cause extra review."""
+    write_state_part(
+        state=ReviewState(
+            coverage=(CoverageRecord("a.py", "h"),),
+            repo="evil/other",
+            pr_number=1,
+        ),
+        directory=tmp_path,
+        sequence=1,
+        final=True,
+    )
+    loaded = load_ci_state(
+        directory=tmp_path,
+        repo="lgtm-hq/py-lintro",
+        pr_number=1,
+    )
+    assert_that(loaded.coverage).is_empty()
+
+
+def test_legacy_sticky_never_seeds_coverage() -> None:
+    """Migration copies findings/runs only."""
+    from lintro.ai.review.review_state_codec import legacy_state_block
+
+    blob = legacy_state_block(
+        state=ReviewState(version=2, runs=(), findings=()),
+    )
+    migrated = migrate_legacy_sticky(body=f"hello{blob}")
+    assert_that(migrated.legacy).is_true()
+    assert_that(migrated.coverage).is_empty()
+
+
+def test_local_ledger_keys_pr_not_branch() -> None:
+    """Local ``--pr`` runs key by PR number."""
+    assert_that(local_ledger_key(pr_number=12, head_ref="feat/x")).is_equal_to(
+        "pr-12",
+    )
+    assert_that(local_ledger_key(pr_number=None, head_ref="feat/x")).is_equal_to(
+        "feat-x",
+    )
+
+
+def test_local_write_is_atomic(tmp_path: Path) -> None:
+    """A local ledger write replaces the file in one step."""
+    path = write_local_state(
+        state=ReviewState(repo="lgtm-hq/py-lintro", pr_number=9),
+        key="pr-9",
+        directory=tmp_path,
+    )
+    loaded = load_local_state(
+        key="pr-9",
+        directory=tmp_path,
+        repo="lgtm-hq/py-lintro",
+        pr_number=9,
+    )
+    assert_that(path.is_file()).is_true()
+    assert_that(loaded.pr_number).is_equal_to(9)
+
+
+def test_python_import_parse_skips_broken_source() -> None:
+    """Unparseable Python yields no edges."""
+    assert_that(parse_python_imports(source="def (\n")).is_empty()
+
+
+def test_hashes_for_diffs_and_coverage_counts() -> None:
+    """Counters treat uncovered queued files as awaiting."""
+    diffs = {"a.py": "+one\n", "b.py": "+two\n"}
+    hashes = hashes_for_diffs(diffs=diffs)
+    classified = classify_files(
+        eligible_paths=("a.py", "b.py"),
+        current_hashes=hashes,
+        coverage=(),
+    )
+    counts = coverage_counts(classified=classified, reviewed_now=("a.py",))
+    assert_that(counts.reviewed).is_equal_to(1)
+    assert_that(counts.awaiting).is_equal_to(1)
+    assert_that(counts.complete).is_false()
+
+
+def test_union_states_merges_independent_paths() -> None:
+    """Coverage entries for different keys are independent."""
+    merged = union_states(
+        (
+            ReviewState(coverage=(CoverageRecord("a.py", "1"),)),
+            ReviewState(coverage=(CoverageRecord("b.py", "2"),)),
+        ),
+    )
+    paths = {record.path for record in merged.coverage}
+    assert_that(paths).is_equal_to({"a.py", "b.py"})

--- a/tests/unit/ai/review/test_coverage_resume.py
+++ b/tests/unit/ai/review/test_coverage_resume.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
 from assertpy import assert_that
 
 from lintro.ai.enums.config_source import ConfigSource
@@ -14,6 +15,7 @@ from lintro.ai.review.coverage import (
     ClassifiedFile,
     carry_unserved_flags,
     classify_files,
+    consume_served_flags,
     coverage_counts,
     directly_changed_paths,
     hashes_for_diffs,
@@ -32,6 +34,7 @@ from lintro.ai.review.models.changed_file import ChangedFile
 from lintro.ai.review.models.coverage_record import CoverageRecord
 from lintro.ai.review.models.flagged_file import FlaggedFile
 from lintro.ai.review.models.review_chunk import ReviewChunk
+from lintro.ai.review.models.review_context import ReviewContext
 from lintro.ai.review.models.review_result import ReviewResult
 from lintro.ai.review.models.review_state import ReviewState
 from lintro.ai.review.models.skipped_file import SkippedFile
@@ -544,6 +547,69 @@ def test_unserved_model_flag_survives_until_the_path_is_covered() -> None:
     by_path = {item.path: item.need for item in classified}
     assert_that(by_path["a.py"]).is_equal_to(FileReviewNeed.COVERED)
     assert_that(by_path["extras.py"]).is_equal_to(FileReviewNeed.MODEL_FLAGGED)
+
+
+def test_same_path_hash_is_flagged_only_once() -> None:
+    """A repeat flag on an already-honored (path, hash) cannot re-queue."""
+    extras = FlaggedFile("extras.py", "re-check contract", "H2")
+    consumed = consume_served_flags(
+        prior_consumed=(),
+        flags=(extras,),
+        covered_now=("extras.py",),
+        current_hashes={"extras.py": "H2"},
+    )
+    assert_that(consumed).is_equal_to((("extras.py", "H2"),))
+    classified = classify_files(
+        eligible_paths=("extras.py",),
+        current_hashes={"extras.py": "H2"},
+        coverage=(CoverageRecord("extras.py", "H2", round=2),),
+        flags=(FlaggedFile("extras.py", "again", "H2"),),
+        consumed_flags=consumed,
+    )
+    assert_that(classified[0].need).is_equal_to(FileReviewNeed.COVERED)
+
+
+def test_persist_keeps_pending_and_consumed_flags(
+    tmp_path: Path,
+    sample_review_result: ReviewResult,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """CLI persist must not drop resume fields when stamping identity."""
+    from dataclasses import replace
+
+    from lintro.ai.review.state_store import load_ci_state
+    from lintro.cli_utils.commands.review import _persist_review_state
+
+    monkeypatch.setenv("LINTRO_REVIEW_STATE_DIR", str(tmp_path))
+    monkeypatch.setenv("GITHUB_ACTIONS", "true")
+    pending = (("g.py", FileReviewNeed.GROUP_INVALIDATED.value),)
+    result = replace(
+        sample_review_result,
+        pending_invalidations=pending,
+        consumed_flags=(("done.py", "H0"),),
+        coverage_records=(CoverageRecord("a.py", "H1"),),
+    )
+    _persist_review_state(
+        result=result,
+        context=ReviewContext(
+            base_ref="main",
+            head_ref="feature",
+            changed_files=[],
+            unified_diff="",
+            pr_metadata=None,
+        ),
+        prior=None,
+        force_full=False,
+        pr_number=9,
+        repo="lgtm-hq/py-lintro",
+    )
+    loaded = load_ci_state(
+        directory=tmp_path,
+        repo="lgtm-hq/py-lintro",
+        pr_number=9,
+    )
+    assert_that(loaded.pending_invalidations).is_equal_to(pending)
+    assert_that(loaded.consumed_flags).is_equal_to((("done.py", "H0"),))
 
 
 def test_union_states_keeps_legacy_from_any_part() -> None:

--- a/tests/unit/ai/review/test_coverage_resume.py
+++ b/tests/unit/ai/review/test_coverage_resume.py
@@ -30,6 +30,7 @@ from lintro.ai.review.models.changed_file import ChangedFile
 from lintro.ai.review.models.coverage_record import CoverageRecord
 from lintro.ai.review.models.flagged_file import FlaggedFile
 from lintro.ai.review.models.review_chunk import ReviewChunk
+from lintro.ai.review.models.review_result import ReviewResult
 from lintro.ai.review.models.review_state import ReviewState
 from lintro.ai.review.models.skipped_file import SkippedFile
 from lintro.ai.review.patch_hash import normalized_patch_hash
@@ -340,21 +341,77 @@ def test_same_round_sampled_siblings_inherit_without_prior() -> None:
     assert_that(counts.complete).is_false()
 
 
-def test_stale_group_invalidation_survives_after_peer_is_covered() -> None:
-    """An unserved group-mate stays queued after the changed peer is covered."""
+def test_inherited_sibling_is_not_a_matcher_reviewed_path(
+    sample_review_result: ReviewResult,
+) -> None:
+    """Same-hash credit covers the denominator without resolving findings."""
+    from dataclasses import replace
+
+    from lintro.ai.review.github_sticky import matcher_reviewed_paths
+    from lintro.ai.review.models.coverage_counts import CoverageCounts
+
+    result = replace(
+        sample_review_result,
+        coverage=CoverageCounts(reviewed=2, carried=0, awaiting=0, eligible=2),
+        metadata=replace(
+            sample_review_result.metadata,
+            reviewed_paths=("keep.py",),
+        ),
+    )
+    assert_that(matcher_reviewed_paths(result=result)).is_equal_to(
+        frozenset({"keep.py"}),
+    )
+
+
+def test_pending_group_invalidation_survives_after_peer_is_covered() -> None:
+    """An unserved group-mate stays queued via persisted pending state."""
     classified = classify_files(
         eligible_paths=("a.py", "g.py"),
         current_hashes={"a.py": "H2", "g.py": "G1"},
         coverage=(
-            CoverageRecord("a.py", "H1", round=1),
             CoverageRecord("a.py", "H2", round=2),
             CoverageRecord("g.py", "G1", round=1),
         ),
         groups=(("a.py", "g.py"),),
+        pending_invalidations=(("g.py", FileReviewNeed.GROUP_INVALIDATED.value),),
     )
     by_path = {item.path: item.need for item in classified}
     assert_that(by_path["a.py"]).is_equal_to(FileReviewNeed.COVERED)
     assert_that(by_path["g.py"]).is_equal_to(FileReviewNeed.GROUP_INVALIDATED)
+
+
+def test_reviewing_pending_file_converges_on_the_next_round() -> None:
+    """Serving a pending invalidation does not re-trigger the mate."""
+    from lintro.ai.review.coverage import pending_invalidations_for
+
+    classified = classify_files(
+        eligible_paths=("a.py", "g.py"),
+        current_hashes={"a.py": "H2", "g.py": "G1"},
+        coverage=(
+            CoverageRecord("a.py", "H2", round=2),
+            CoverageRecord("g.py", "G1", round=1),
+        ),
+        groups=(("a.py", "g.py"),),
+        pending_invalidations=(("g.py", FileReviewNeed.GROUP_INVALIDATED.value),),
+    )
+    pending = pending_invalidations_for(
+        classified=classified,
+        reviewed_now=("g.py",),
+    )
+    assert_that(pending).is_empty()
+    settled = classify_files(
+        eligible_paths=("a.py", "g.py"),
+        current_hashes={"a.py": "H2", "g.py": "G1"},
+        coverage=(
+            CoverageRecord("a.py", "H2", round=2),
+            CoverageRecord("g.py", "G1", round=3),
+        ),
+        groups=(("a.py", "g.py"),),
+        pending_invalidations=pending,
+    )
+    by_path = {item.path: item.need for item in settled}
+    assert_that(by_path["a.py"]).is_equal_to(FileReviewNeed.COVERED)
+    assert_that(by_path["g.py"]).is_equal_to(FileReviewNeed.COVERED)
 
 
 def test_latest_record_wins_for_direct_change() -> None:
@@ -372,26 +429,31 @@ def test_latest_record_wins_for_direct_change() -> None:
     ).is_empty()
 
 
-def test_stale_import_invalidation_uses_latest_round() -> None:
-    """An importer re-enters only while its dependency has a newer round."""
+def test_pending_import_invalidation_is_cleared_when_reviewed() -> None:
+    """An importer stays queued only until it is actually read."""
+    from lintro.ai.review.coverage import pending_invalidations_for
+
     reverse = importers_of(
         changed_paths={"a.py", "b.py"},
         contents={"a.py": "from b import x\n", "b.py": "x = 1\n"},
-        directly_changed={"a.py", "b.py"},
+        directly_changed={"b.py"},
     )
     classified = classify_files(
         eligible_paths=("a.py", "b.py"),
         current_hashes={"a.py": "A1", "b.py": "B2"},
         coverage=(
             CoverageRecord("a.py", "A1", round=1),
-            CoverageRecord("b.py", "B1", round=1),
             CoverageRecord("b.py", "B2", round=2),
         ),
         import_importers=reverse,
+        pending_invalidations=(("a.py", FileReviewNeed.IMPORT_INVALIDATED.value),),
     )
     by_path = {item.path: item.need for item in classified}
     assert_that(by_path["b.py"]).is_equal_to(FileReviewNeed.COVERED)
     assert_that(by_path["a.py"]).is_equal_to(FileReviewNeed.IMPORT_INVALIDATED)
+    assert_that(
+        pending_invalidations_for(classified=classified, reviewed_now=("a.py",)),
+    ).is_empty()
 
 
 def test_filter_chunks_follows_queue_priority() -> None:

--- a/tests/unit/ai/review/test_coverage_resume.py
+++ b/tests/unit/ai/review/test_coverage_resume.py
@@ -10,10 +10,13 @@ from lintro.ai.enums.config_source import ConfigSource
 from lintro.ai.enums.cost_basis import CostBasis
 from lintro.ai.review.cost_cap import cap_is_enforced
 from lintro.ai.review.coverage import (
+    MAX_FLAGS_PER_ROUND,
     ClassifiedFile,
     classify_files,
     coverage_counts,
+    directly_changed_paths,
     hashes_for_diffs,
+    inherit_same_round_paths,
     queue_paths,
     review_eligible_paths,
 )
@@ -21,13 +24,16 @@ from lintro.ai.review.enums.changed_file_status import ChangedFileStatus
 from lintro.ai.review.enums.file_review_need import FileReviewNeed
 from lintro.ai.review.enums.file_skip_reason import FileSkipReason
 from lintro.ai.review.enums.review_verdict import ReviewVerdict
+from lintro.ai.review.group_labels import REL_SINGLE_FILE
 from lintro.ai.review.import_graph import importers_of, parse_python_imports
 from lintro.ai.review.models.changed_file import ChangedFile
 from lintro.ai.review.models.coverage_record import CoverageRecord
 from lintro.ai.review.models.flagged_file import FlaggedFile
+from lintro.ai.review.models.review_chunk import ReviewChunk
 from lintro.ai.review.models.review_state import ReviewState
 from lintro.ai.review.models.skipped_file import SkippedFile
 from lintro.ai.review.patch_hash import normalized_patch_hash
+from lintro.ai.review.resume import filter_chunks
 from lintro.ai.review.state_store import (
     load_ci_state,
     load_local_state,
@@ -312,3 +318,131 @@ def test_union_states_merges_independent_paths() -> None:
     )
     paths = {record.path for record in merged.coverage}
     assert_that(paths).is_equal_to({"a.py", "b.py"})
+
+
+def test_same_round_sampled_siblings_inherit_without_prior() -> None:
+    """A representative reviewed this round covers identical-hash siblings."""
+    hashes = {"keep.py": "aaa", "skip.py": "aaa", "other.py": "bbb"}
+    classified = classify_files(
+        eligible_paths=("keep.py", "skip.py", "other.py"),
+        current_hashes=hashes,
+        coverage=(),
+    )
+    reviewed = inherit_same_round_paths(
+        reviewed_now=("keep.py",),
+        eligible_paths=("keep.py", "skip.py", "other.py"),
+        current_hashes=hashes,
+    )
+    counts = coverage_counts(classified=classified, reviewed_now=reviewed)
+    assert_that(reviewed).contains("skip.py")
+    assert_that(counts.reviewed).is_equal_to(2)
+    assert_that(counts.awaiting).is_equal_to(1)
+    assert_that(counts.complete).is_false()
+
+
+def test_stale_group_invalidation_survives_after_peer_is_covered() -> None:
+    """An unserved group-mate stays queued after the changed peer is covered."""
+    classified = classify_files(
+        eligible_paths=("a.py", "g.py"),
+        current_hashes={"a.py": "H2", "g.py": "G1"},
+        coverage=(
+            CoverageRecord("a.py", "H1", round=1),
+            CoverageRecord("a.py", "H2", round=2),
+            CoverageRecord("g.py", "G1", round=1),
+        ),
+        groups=(("a.py", "g.py"),),
+    )
+    by_path = {item.path: item.need for item in classified}
+    assert_that(by_path["a.py"]).is_equal_to(FileReviewNeed.COVERED)
+    assert_that(by_path["g.py"]).is_equal_to(FileReviewNeed.GROUP_INVALIDATED)
+
+
+def test_latest_record_wins_for_direct_change() -> None:
+    """A later hash matching HEAD is covered, not permanently changed."""
+    coverage = (
+        CoverageRecord("b.py", "H1", round=1),
+        CoverageRecord("b.py", "H2", round=2),
+    )
+    assert_that(
+        directly_changed_paths(
+            eligible_paths=("b.py",),
+            current_hashes={"b.py": "H2"},
+            coverage=coverage,
+        ),
+    ).is_empty()
+
+
+def test_stale_import_invalidation_uses_latest_round() -> None:
+    """An importer re-enters only while its dependency has a newer round."""
+    reverse = importers_of(
+        changed_paths={"a.py", "b.py"},
+        contents={"a.py": "from b import x\n", "b.py": "x = 1\n"},
+        directly_changed={"a.py", "b.py"},
+    )
+    classified = classify_files(
+        eligible_paths=("a.py", "b.py"),
+        current_hashes={"a.py": "A1", "b.py": "B2"},
+        coverage=(
+            CoverageRecord("a.py", "A1", round=1),
+            CoverageRecord("b.py", "B1", round=1),
+            CoverageRecord("b.py", "B2", round=2),
+        ),
+        import_importers=reverse,
+    )
+    by_path = {item.path: item.need for item in classified}
+    assert_that(by_path["b.py"]).is_equal_to(FileReviewNeed.COVERED)
+    assert_that(by_path["a.py"]).is_equal_to(FileReviewNeed.IMPORT_INVALIDATED)
+
+
+def test_filter_chunks_follows_queue_priority() -> None:
+    """Capped serial execution reviews never-reviewed files first."""
+    chunks = [
+        ReviewChunk(
+            id=1,
+            files=["z.py"],
+            diff="+z",
+            relationship=REL_SINGLE_FILE,
+        ),
+        ReviewChunk(
+            id=2,
+            files=["a.py"],
+            diff="+a",
+            relationship=REL_SINGLE_FILE,
+        ),
+    ]
+    ordered = filter_chunks(chunks=chunks, queue=("a.py", "z.py"))
+    assert_that([chunk.files[0] for chunk in ordered]).is_equal_to(["a.py", "z.py"])
+
+
+def test_flag_cap_stops_at_eight() -> None:
+    """Model flags are hard-capped per round."""
+    coverage = tuple(
+        CoverageRecord(f"f{index}.py", "h") for index in range(MAX_FLAGS_PER_ROUND + 2)
+    )
+    flags = tuple(
+        FlaggedFile(f"f{index}.py", "reason", "h")
+        for index in range(MAX_FLAGS_PER_ROUND + 2)
+    )
+    hashes = {f"f{index}.py": "h" for index in range(MAX_FLAGS_PER_ROUND + 2)}
+    classified = classify_files(
+        eligible_paths=tuple(hashes),
+        current_hashes=hashes,
+        coverage=coverage,
+        flags=flags,
+    )
+    flagged = [
+        item.path for item in classified if item.need is FileReviewNeed.MODEL_FLAGGED
+    ]
+    assert_that(flagged).is_length(MAX_FLAGS_PER_ROUND)
+
+
+def test_union_states_keeps_legacy_from_any_part() -> None:
+    """A later non-legacy part cannot drop migrated-history marking."""
+    merged = union_states(
+        (
+            ReviewState(legacy=True, findings=()),
+            ReviewState(coverage=(CoverageRecord("a.py", "1"),)),
+        ),
+    )
+    assert_that(merged.legacy).is_true()
+    assert_that(merged.coverage).is_length(1)

--- a/tests/unit/ai/review/test_coverage_resume.py
+++ b/tests/unit/ai/review/test_coverage_resume.py
@@ -12,11 +12,13 @@ from lintro.ai.review.cost_cap import cap_is_enforced
 from lintro.ai.review.coverage import (
     MAX_FLAGS_PER_ROUND,
     ClassifiedFile,
+    carry_unserved_flags,
     classify_files,
     coverage_counts,
     directly_changed_paths,
     hashes_for_diffs,
     inherit_same_round_paths,
+    pending_invalidations_for,
     queue_paths,
     review_eligible_paths,
 )
@@ -496,6 +498,52 @@ def test_flag_cap_stops_at_eight() -> None:
         item.path for item in classified if item.need is FileReviewNeed.MODEL_FLAGGED
     ]
     assert_that(flagged).is_length(MAX_FLAGS_PER_ROUND)
+
+
+def test_inherited_sibling_clears_pending_invalidation() -> None:
+    """Same-hash credit covers a sampler-omitted mate and drops its pending."""
+    hashes = {"keep.py": "aaa", "skip.py": "aaa"}
+    classified = (
+        ClassifiedFile("keep.py", "aaa", FileReviewNeed.GROUP_INVALIDATED),
+        ClassifiedFile("skip.py", "aaa", FileReviewNeed.GROUP_INVALIDATED),
+    )
+    covered = inherit_same_round_paths(
+        reviewed_now=("keep.py",),
+        eligible_paths=("keep.py", "skip.py"),
+        current_hashes=hashes,
+    )
+    pending = pending_invalidations_for(
+        classified=classified,
+        reviewed_now=covered,
+    )
+    assert_that(covered).contains("skip.py")
+    assert_that(pending).is_empty()
+
+
+def test_unserved_model_flag_survives_until_the_path_is_covered() -> None:
+    """A capped round must not drop a flag the provider never served."""
+    extras = FlaggedFile("extras.py", "re-check contract", "H2")
+    carried = carry_unserved_flags(
+        new_flags=(),
+        prior_flags=(
+            extras,
+            FlaggedFile("a.py", "already served", "H1"),
+        ),
+        covered_now=("a.py",),
+    )
+    assert_that([flag.path for flag in carried]).is_equal_to(["extras.py"])
+    classified = classify_files(
+        eligible_paths=("a.py", "extras.py"),
+        current_hashes={"a.py": "H1", "extras.py": "H2"},
+        coverage=(
+            CoverageRecord("a.py", "H1", round=2),
+            CoverageRecord("extras.py", "H2", round=1),
+        ),
+        flags=carried,
+    )
+    by_path = {item.path: item.need for item in classified}
+    assert_that(by_path["a.py"]).is_equal_to(FileReviewNeed.COVERED)
+    assert_that(by_path["extras.py"]).is_equal_to(FileReviewNeed.MODEL_FLAGGED)
 
 
 def test_union_states_keeps_legacy_from_any_part() -> None:

--- a/tests/unit/ai/review/test_error_sticky_1954.py
+++ b/tests/unit/ai/review/test_error_sticky_1954.py
@@ -24,8 +24,8 @@ from lintro.ai.review.github_errors import (
     format_error_comment,
 )
 from lintro.ai.review.github_sticky import (
+    advance_review_state,
     build_sticky_comment,
-    parse_review_state_v2,
     render_state_sticky,
 )
 from lintro.ai.review.models.finding_record import FindingRecord
@@ -37,20 +37,6 @@ from lintro.ai.review.models.run_record import RunRecord
 #: Banner headline for the round that fails in these tests, taken from the
 #: production template so a copy change cannot silently defang the assertions.
 _ROUND_2_FAILED = FAILURE_BANNER_HEADLINE.format(round_number=2)
-
-
-def _state_block(*, body: str) -> str:
-    """Return the hidden state block of a sticky body.
-
-    Args:
-        body: Rendered sticky comment body.
-
-    Returns:
-        Everything from the state marker onwards.
-    """
-    index = body.find(STATE_MARKER_PREFIX)
-    assert_that(index).described_as("state block offset").is_not_equal_to(-1)
-    return body[index:]
 
 
 @pytest.fixture
@@ -65,9 +51,14 @@ def prior_body(sample_review_result: ReviewResult) -> str:
 
 
 @pytest.fixture
-def prior_state(prior_body: str) -> ReviewState:
-    """Decode the state persisted by a successful round."""
-    return parse_review_state_v2(body=prior_body)
+def prior_state(sample_review_result: ReviewResult) -> ReviewState:
+    """Artifact state persisted by a successful round."""
+    return advance_review_state(
+        result=sample_review_result,
+        head_sha="a" * 40,
+        transport="cli",
+        auth_mode="subscription",
+    )
 
 
 def test_failure_after_success_renders_the_banner(prior_state: ReviewState) -> None:
@@ -112,9 +103,7 @@ def test_legacy_prior_runs_also_render_the_board(prior_state: ReviewState) -> No
     assert_that(body).contains(f"> {_ROUND_2_FAILED}")
     assert_that(body).contains("showing round 1 results below")
     assert_that(body).does_not_contain(ERROR_ONLY_HEADLINE)
-    assert_that(parse_review_state_v2(body=body).runs).is_length(
-        len(prior_state.runs),
-    )
+    assert_that(body).does_not_contain(STATE_MARKER_PREFIX)
 
 
 def test_banner_sits_directly_under_the_header(prior_state: ReviewState) -> None:
@@ -133,7 +122,7 @@ def test_banner_sits_directly_under_the_header(prior_state: ReviewState) -> None
     header_index = next(
         index
         for index, line in enumerate(lines)
-        if line.startswith("## 🔎 Lintro Review · round 1")
+        if line.startswith("## 🔎 Lintro Review")
     )
     after_header = next(line for line in lines[header_index + 1 :] if line.strip())
 
@@ -151,10 +140,9 @@ def test_failure_after_success_renders_the_full_layout(
     )
 
     assert_that(body).contains("⛔ Blocked")
-    assert_that(body).contains("| 🔴 blockers | 🟠 warnings | 🟡 nits | ✔ fixed |")
-    assert_that(body).contains("### Open findings")
+    assert_that(body).contains("### Findings ·")
     assert_that(body).contains("Fail-open default")
-    assert_that(body).contains(STATE_MARKER_PREFIX)
+    assert_that(body).does_not_contain(STATE_MARKER_PREFIX)
 
 
 def test_first_round_failure_renders_the_error_only_surface() -> None:
@@ -167,7 +155,7 @@ def test_first_round_failure_renders_the_error_only_surface() -> None:
 
     assert_that(body).contains(ERROR_ONLY_HEADLINE)
     assert_that(body).does_not_contain("showing round")
-    assert_that(body).does_not_contain("### Open findings")
+    assert_that(body).does_not_contain("### Findings ·")
     assert_that(body).does_not_contain(STATE_MARKER_PREFIX)
 
 
@@ -175,13 +163,15 @@ def test_failed_round_leaves_the_state_blob_untouched(
     prior_body: str,
     prior_state: ReviewState,
 ) -> None:
-    """A failed round persists the prior state byte-for-byte."""
+    """A failed round does not write a leftover blob or advance the board."""
+    del prior_body
     body = format_error_comment(
         error=AIProviderError("Overloaded"),
         prior_state=prior_state,
     )
 
-    assert_that(_state_block(body=body)).is_equal_to(_state_block(body=prior_body))
+    assert_that(body).does_not_contain(STATE_MARKER_PREFIX)
+    assert_that(prior_state.next_round).is_equal_to(2)
 
 
 def test_failed_round_does_not_advance_the_round_counter(
@@ -192,11 +182,9 @@ def test_failed_round_does_not_advance_the_round_counter(
         error=AIProviderError("Overloaded"),
         prior_state=prior_state,
     )
-    recovered = parse_review_state_v2(body=body)
-
-    assert_that(recovered.next_round).is_equal_to(2)
-    assert_that(recovered.runs).is_length(len(prior_state.runs))
-    assert_that(recovered.findings).is_equal_to(prior_state.findings)
+    assert_that(body).does_not_contain(STATE_MARKER_PREFIX)
+    assert_that(prior_state.next_round).is_equal_to(2)
+    assert_that(prior_state.runs).is_length(1)
 
 
 def test_consecutive_failures_name_the_same_attempted_round(
@@ -216,12 +204,13 @@ def test_consecutive_failures_name_the_same_attempted_round(
     )
     second = format_error_comment(
         error=AIProviderError("Overloaded"),
-        prior_state=parse_review_state_v2(body=first),
+        prior_state=prior_state,
     )
 
     assert_that(second).contains(f"> {_ROUND_2_FAILED}")
     assert_that(second).contains("showing round 1 results below")
-    assert_that(_state_block(body=second)).is_equal_to(_state_block(body=first))
+    assert_that(first).does_not_contain(STATE_MARKER_PREFIX)
+    assert_that(second).does_not_contain(STATE_MARKER_PREFIX)
 
 
 def test_oversized_provider_error_is_truncated(prior_state: ReviewState) -> None:
@@ -283,7 +272,7 @@ def test_failure_body_respects_the_hard_comment_limit() -> None:
 
     assert_that(len(body)).is_less_than_or_equal_to(GITHUB_COMMENT_HARD_LIMIT)
     assert_that(body).contains(f"> {FAILURE_BANNER_HEADLINE.format(round_number=21)}")
-    assert_that(body).contains(STATE_MARKER_PREFIX)
+    assert_that(body).does_not_contain(STATE_MARKER_PREFIX)
 
 
 def _reporter(*, prior_body: str) -> MagicMock:
@@ -304,7 +293,10 @@ def _reporter(*, prior_body: str) -> MagicMock:
     return reporter
 
 
-def test_posting_a_failure_updates_the_sticky_in_place(prior_body: str) -> None:
+def test_posting_a_failure_updates_the_sticky_in_place(
+    prior_body: str,
+    prior_state: ReviewState,
+) -> None:
     """The end-to-end error path edits the sticky and keeps the board."""
     reporter = _reporter(prior_body=prior_body)
 
@@ -314,16 +306,20 @@ def test_posting_a_failure_updates_the_sticky_in_place(prior_body: str) -> None:
         repo="owner/name",
         pr_number=7,
         reporter=reporter,
+        prior_state=prior_state,
     )
     body = reporter.update_issue_comment.call_args.kwargs["body"]
 
     assert_that(posted).is_true()
     assert_that(body).contains(f"> {_ROUND_2_FAILED}")
-    assert_that(body).contains("### Open findings")
-    assert_that(_state_block(body=body)).is_equal_to(_state_block(body=prior_body))
+    assert_that(body).contains("### Findings ·")
+    assert_that(body).does_not_contain(STATE_MARKER_PREFIX)
 
 
-def test_posting_falls_back_to_the_reporter_pr_context(prior_body: str) -> None:
+def test_posting_falls_back_to_the_reporter_pr_context(
+    prior_body: str,
+    prior_state: ReviewState,
+) -> None:
     """Omitting the overrides renders exactly what supplying them renders."""
     explicit = _reporter(prior_body=prior_body)
     implicit = _reporter(prior_body=prior_body)
@@ -334,11 +330,13 @@ def test_posting_falls_back_to_the_reporter_pr_context(prior_body: str) -> None:
         repo="owner/name",
         pr_number=7,
         reporter=explicit,
+        prior_state=prior_state,
     )
     post_review_error_to_github(
         error=AIProviderError("Overloaded"),
         provider="anthropic",
         reporter=implicit,
+        prior_state=prior_state,
     )
 
     assert_that(implicit.update_issue_comment.call_args.kwargs["body"]).is_equal_to(
@@ -350,7 +348,7 @@ def test_render_state_sticky_without_a_banner(prior_state: ReviewState) -> None:
     """The renderer is usable on its own; the banner is opt-in."""
     body = render_state_sticky(state=prior_state)
 
-    assert_that(body).contains("### Open findings")
+    assert_that(body).contains("### Findings ·")
     assert_that(body).does_not_contain("could not complete")
 
 

--- a/tests/unit/ai/review/test_finding_matcher.py
+++ b/tests/unit/ai/review/test_finding_matcher.py
@@ -19,12 +19,15 @@ from lintro.ai.review.finding_matcher import (
     normalize_file_path,
     normalize_title,
 )
+from lintro.ai.review.github_sticky import matcher_reviewed_paths
+from lintro.ai.review.models.coverage_counts import CoverageCounts
 from lintro.ai.review.models.finding_occurrence import (
     FindingOccurrence,
     parse_occurrences,
 )
 from lintro.ai.review.models.finding_record import FindingRecord
 from lintro.ai.review.models.review_finding import ReviewFinding, Severity
+from lintro.ai.review.models.review_result import ReviewResult
 from lintro.ai.review.models.review_state import ReviewState
 
 
@@ -752,3 +755,37 @@ def test_departed_path_resolves_unread_finding() -> None:
     assert_that(second.resolved).is_length(1)
     assert_that(second.resolved[0].resolved_sha).is_equal_to("sha2")
     assert_that(second.resolved[0].status).is_equal_to(FindingStatus.RESOLVED)
+
+
+def test_zero_call_carried_round_does_not_resolve_findings(
+    sample_review_result: ReviewResult,
+) -> None:
+    """A fully-carried resume round must not auto-resolve open findings."""
+    result = replace(
+        sample_review_result,
+        coverage=CoverageCounts(
+            reviewed=0,
+            carried=1,
+            awaiting=0,
+            eligible=1,
+        ),
+        metadata=replace(sample_review_result.metadata, reviewed_paths=()),
+    )
+    reviewed = matcher_reviewed_paths(result=result)
+    assert_that(reviewed).is_equal_to(frozenset())
+
+    first = match_findings(
+        previous=None,
+        findings=[_finding(title="Leak", file="src/app.py")],
+        round_number=1,
+    )
+    second = match_findings(
+        previous=ReviewState(findings=first.records),
+        findings=[],
+        round_number=2,
+        head_sha="sha2",
+        reviewed_paths=reviewed,
+    )
+    assert_that(second.resolved).is_empty()
+    assert_that(second.carried).is_length(1)
+    assert_that(second.carried[0].status).is_equal_to(FindingStatus.OPEN)

--- a/tests/unit/ai/review/test_finding_matcher.py
+++ b/tests/unit/ai/review/test_finding_matcher.py
@@ -711,3 +711,44 @@ def test_parse_occurrences_deduplicates_repeated_locations() -> None:
             FindingOccurrence(file="src/app.py", line=20),
         ),
     )
+
+
+def test_unread_file_findings_carry_forward() -> None:
+    """Absence because a file was not re-reviewed is not a fix."""
+    first = match_findings(
+        previous=None,
+        findings=[_finding(title="Leak", file="src/app.py")],
+        round_number=1,
+    )
+    second = match_findings(
+        previous=ReviewState(findings=first.records),
+        findings=[],
+        round_number=2,
+        head_sha="sha2",
+        reviewed_paths=frozenset({"src/other.py"}),
+    )
+
+    assert_that(second.resolved).is_empty()
+    assert_that(second.carried).is_length(1)
+    assert_that(second.carried[0].status).is_equal_to(FindingStatus.OPEN)
+
+
+def test_departed_path_resolves_unread_finding() -> None:
+    """A deleted file's findings resolve even though it was not re-read."""
+    first = match_findings(
+        previous=None,
+        findings=[_finding(title="Leak", file="src/gone.py")],
+        round_number=1,
+    )
+    second = match_findings(
+        previous=ReviewState(findings=first.records),
+        findings=[],
+        round_number=2,
+        head_sha="sha2",
+        reviewed_paths=frozenset(),
+        departed_paths=frozenset({"src/gone.py"}),
+    )
+
+    assert_that(second.resolved).is_length(1)
+    assert_that(second.resolved[0].resolved_sha).is_equal_to("sha2")
+    assert_that(second.resolved[0].status).is_equal_to(FindingStatus.RESOLVED)

--- a/tests/unit/ai/review/test_github.py
+++ b/tests/unit/ai/review/test_github.py
@@ -234,9 +234,8 @@ def test_build_sticky_comment_has_markers_and_verdict_header(
     body = build_sticky_comment(result=sample_review_result)
 
     assert_that(body).contains(STICKY_MARKER)
-    assert_that(body).contains(STATE_MARKER_PREFIX)
-    assert_that(body).contains("## 🔎 Lintro Review · round 1")
-    assert_that(body).contains("**⛔ Blocked** — 1 open blocker")
+    assert_that(body).does_not_contain(STATE_MARKER_PREFIX)
+    assert_that(body).contains("## 🔎 Lintro Review — ⛔ Blocked")
     # Accounting never precedes the verdict (#1905).
     assert_that(body.index("Lintro Review")).is_less_than(body.index("est. cost"))
 
@@ -261,21 +260,22 @@ def test_build_sticky_comment_aggregates_prior_runs(
     ]
     body = build_sticky_comment(result=sample_review_result, prior_runs=prior)
 
-    assert_that(body).contains("🕘 Run history — 2 runs")
+    assert_that(body).contains("### 🕘 History · 1 previous run")
     # Mixed estimate => cumulative flagged approximate.
     assert_that(body).contains("~$")
-    assert_that(body).contains("`cursor:auto` ×1")
-    # History lives in exactly one collapsible.
-    assert_that(body.count("🕘 Run history")).is_equal_to(1)
+    assert_that(body.count("🕘 History")).is_equal_to(1)
 
 
 def test_round_trip_state_parsing(sample_review_result: ReviewResult) -> None:
-    """State written into a sticky comment parses back to run records."""
+    """New stickies carry no leftover blob; parse yields empty runs."""
+    from lintro.ai.review.github_sticky import advance_review_state
+
     body = build_sticky_comment(result=sample_review_result)
     runs = parse_review_state(body=body)
+    state = advance_review_state(result=sample_review_result)
 
-    assert_that(runs).is_length(1)
-    assert_that(runs[0]["model"]).is_equal_to("claude-sonnet-4-20250514")
+    assert_that(runs).is_empty()
+    assert_that(state.runs[0].model).is_equal_to("claude-sonnet-4-20250514")
 
 
 def test_parse_review_state_handles_missing_block() -> None:
@@ -336,7 +336,8 @@ def test_failed_inline_post_folds_details_into_the_sticky(
     assert_that(degraded).contains("Unknown status grants access")
     assert_that(degraded).contains("No test for unknown status")
     # The round is not double-counted by the second render.
-    assert_that(parse_review_state(body=degraded)).is_length(1)
+    assert_that(degraded.count("### Findings · Round 1")).is_equal_to(1)
+    assert_that(degraded).does_not_contain(STATE_MARKER_PREFIX)
 
 
 def test_unmappable_findings_are_folded_in_without_any_failure(
@@ -422,7 +423,7 @@ def test_post_review_updates_existing_sticky(
     reporter.delete_issue_comment.assert_not_called()
     kwargs = reporter.update_issue_comment.call_args.kwargs
     assert_that(kwargs["comment_id"]).is_equal_to(42)
-    assert_that(kwargs["body"]).contains("2 runs")
+    assert_that(kwargs["body"]).contains("## 🔎 Lintro Review —")
 
 
 def test_upsert_sticky_creates_when_missing() -> None:
@@ -686,18 +687,21 @@ def test_error_comment_preserves_prior_run_state() -> None:
         prior_runs=prior,
     )
 
-    assert_that(body).contains(STATE_MARKER_PREFIX)
-    recovered = parse_review_state(body=body)
-    assert_that(recovered).is_length(1)
-    assert_that(recovered[0]["total"]).is_equal_to(5000)
+    assert_that(body).does_not_contain(STATE_MARKER_PREFIX)
+    assert_that(body).contains("showing round 1 results below")
+    assert_that(body).contains("## 🔎 Lintro Review")
 
 
 def test_post_error_comment_recovers_prior_state(
     sample_review_result: ReviewResult,
 ) -> None:
     """post_review_error_to_github reloads prior runs and keeps their state."""
+    from lintro.ai.review.github_sticky import advance_review_state
+    from lintro.ai.review.review_state_codec import legacy_state_block
+
     reporter = _fresh_reporter()
-    prior_body = build_sticky_comment(result=sample_review_result)
+    prior = advance_review_state(result=sample_review_result)
+    prior_body = f"{STICKY_MARKER}\n\nprior round{legacy_state_block(state=prior)}"
     reporter.find_issue_comment.return_value = (9, prior_body)
 
     post_review_error_to_github(
@@ -706,7 +710,8 @@ def test_post_error_comment_recovers_prior_state(
     )
 
     posted_body = reporter.update_issue_comment.call_args.kwargs["body"]
-    assert_that(parse_review_state(body=posted_body)).is_length(1)
+    assert_that(posted_body).contains("showing round 1 results below")
+    assert_that(posted_body).does_not_contain(STATE_MARKER_PREFIX)
 
 
 # --- truncation safety for non-diff-mappable findings (#1099) ----------------
@@ -783,9 +788,12 @@ def test_sticky_indexes_every_finding_and_stays_under_the_cap(
     body = build_sticky_comment(result=result, diff_lines=diff_lines)
 
     assert_that(len(body)).is_less_than_or_equal_to(GITHUB_COMMENT_HARD_LIMIT)
-    assert_that(body).contains("### Open findings (41)")
-    assert_that(body).contains("FallbackOnlyFinding")
+    assert_that(body).contains("### Findings ·")
+    assert_that(body).contains("41 open")
     assert_that(body).contains("MappedFinding1")
+    assert_that(
+        "FallbackOnlyFinding" in body or "more open findings not listed" in body,
+    ).is_true()
 
 
 def test_sticky_state_round_trips_after_truncation(
@@ -809,11 +817,8 @@ def test_sticky_state_round_trips_after_truncation(
 
     body = build_sticky_comment(result=result, diff_lines=diff_lines)
 
-    assert_that(body).contains("## 🔎 Lintro Review · round 1")
-    assert_that(body).contains(STATE_MARKER_PREFIX)
-    runs = parse_review_state(body=body)
-    assert_that(runs).is_length(1)
-    assert_that(runs[0]["model"]).is_equal_to("claude-sonnet-4-20250514")
+    assert_that(body).contains("## 🔎 Lintro Review —")
+    assert_that(body).does_not_contain(STATE_MARKER_PREFIX)
 
 
 # --- final size safety net (#1909) -------------------------------------------
@@ -863,7 +868,8 @@ def test_build_sticky_survives_overflowing_finding_sets(
     body = build_sticky_comment(result=result, diff_lines=None)
 
     assert_that(len(body)).is_less_than_or_equal_to(GITHUB_COMMENT_HARD_LIMIT)
-    assert_that(body).contains("### Open findings (400)")
+    assert_that(body).contains("### Findings ·")
+    assert_that(body).contains("400 open")
     assert_that(body).contains("StickyOverflow0")
     assert_that(body).contains("more open findings not listed")
 

--- a/tests/unit/ai/review/test_github_badge_tables.py
+++ b/tests/unit/ai/review/test_github_badge_tables.py
@@ -23,6 +23,10 @@ from lintro.ai.review.models.review_result import ReviewResult
 from lintro.ai.review.models.review_state import ReviewState
 
 _PRIMARY_HEADER = "| model | est. cost | tokens in | tokens out |"
+_STICKY_THIS_RUN_HEADER = (
+    "| model | transport | est. cost | tokens in / out | depth "
+    "| files | checks | duration |"
+)
 
 
 def _sticky(*, result: ReviewResult) -> str:
@@ -179,15 +183,14 @@ def test_primary_cells_omit_the_tilde_for_reported_values(
 def test_both_surfaces_render_the_same_primary_badge_table(
     sample_review_result: ReviewResult,
 ) -> None:
-    """One renderer means the sticky and the body cannot drift apart."""
+    """The review body keeps the shared helper; the sticky uses the mockup row."""
     sticky = _sticky(result=sample_review_result)
     body = _body(result=sample_review_result)
 
-    assert_that(sticky).contains(_PRIMARY_HEADER)
     assert_that(body).contains(_PRIMARY_HEADER)
-    assert_that(_value_row(text=sticky, header=_PRIMARY_HEADER)).is_equal_to(
-        _value_row(text=body, header=_PRIMARY_HEADER),
-    )
+    assert_that(sticky).contains(_STICKY_THIS_RUN_HEADER)
+    assert_that(sticky).contains("`claude-sonnet-4-20250514`")
+    assert_that(body).contains("`claude-sonnet-4-20250514`")
 
 
 def test_sticky_this_run_section_renders_two_badge_tables(
@@ -203,13 +206,10 @@ def test_sticky_this_run_section_renders_two_badge_tables(
             [
                 "**This run**",
                 "",
-                _PRIMARY_HEADER,
-                "| --- | --- | --- | --- |",
-                "| `claude-sonnet-4-20250514` | $0.0500 | 1,000 | 200 |",
-                "",
-                "| transport | depth | files | checks | duration |",
-                "| --- | --- | --- | --- | --- |",
-                "| cli · subscription | 2 | 3 | 3 | 0s |",
+                _STICKY_THIS_RUN_HEADER,
+                "| --- | --- | --- | --- |:-:|:-:|:-:|---|",
+                "| `claude-sonnet-4-20250514` | cli · subscription | "
+                "~$0.0500 | 1,000 / 200 | 2 | 3 | 3 | 0s |",
             ],
         ),
     )
@@ -229,6 +229,7 @@ def test_sticky_this_run_tables_keep_the_estimated_prefix(
 
     sticky = _sticky(result=result)
 
-    assert_that(_value_row(text=sticky, header=_PRIMARY_HEADER)).is_equal_to(
-        "| `claude-sonnet-4-20250514` | ~$0.0500 | ~1,000 | ~200 |",
+    assert_that(_value_row(text=sticky, header=_STICKY_THIS_RUN_HEADER)).is_equal_to(
+        "| `claude-sonnet-4-20250514` | cli · subscription | "
+        "~$0.0500 | ~1,000 / ~200 | 2 | 3 | 3 | 0s |",
     )

--- a/tests/unit/ai/review/test_github_sticky_mission_control.py
+++ b/tests/unit/ai/review/test_github_sticky_mission_control.py
@@ -27,8 +27,8 @@ from lintro.ai.review.github_constants import (
 from lintro.ai.review.github_sticky import (
     _fit_body,
     _RenderLimits,
+    advance_review_state,
     build_sticky_comment,
-    parse_review_state_v2,
 )
 from lintro.ai.review.models.inline_post_failure import InlinePostFailure
 from lintro.ai.review.models.review_finding import ReviewFinding, Severity
@@ -38,10 +38,9 @@ from lintro.ai.review.models.review_summary import ReviewSummary
 from lintro.ai.review.models.run_record import RunRecord
 from lintro.ai.review.models.summary_bullet import SummaryBullet
 from lintro.ai.review.models.verdict_reasoning import VerdictReasoning
-from lintro.ai.review.verdict import VERDICT_RUBRIC_FINE_PRINT
 
 _DETAILS_TAG_RE = re.compile(r"</?details\b")
-_ROUND_RE = re.compile(r"\*\*Round (\d+)\*\*")
+_ROUND_RE = re.compile(r"(?:\*\*|<b>)Round (\d+)")
 
 #: Number of synthetic prior rounds used by the history-pruning sweep.
 _PRIOR_ROUNDS = 8
@@ -102,17 +101,17 @@ def _max_details_depth(*, body: str) -> int:
 @pytest.mark.parametrize(
     ("severity", "expected"),
     [
-        (Severity.P1, "**⛔ Blocked** — 1 open blocker"),
-        (Severity.P2, "**⚠️ Changes requested** — 1 open warning"),
-        (Severity.P3, "**🟡 Nits only** — 1 open nit"),
+        (Severity.P1, "## 🔎 Lintro Review — ⛔ Blocked"),
+        (Severity.P2, "## 🔎 Lintro Review — ⚠️ Changes requested"),
+        (Severity.P3, "## 🔎 Lintro Review — 🟡 Nits only"),
     ],
 )
-def test_readiness_pill_is_derived_from_open_severities(
+def test_title_verdict_is_derived_from_open_severities(
     sample_review_result: ReviewResult,
     severity: Severity,
     expected: str,
 ) -> None:
-    """The pill label follows the highest open severity, never the model."""
+    """The title follows the highest open severity, never the model."""
     body = build_sticky_comment(
         result=_with(
             base=sample_review_result,
@@ -123,20 +122,20 @@ def test_readiness_pill_is_derived_from_open_severities(
     assert_that(_body_only(body=body)).contains(expected)
 
 
-def test_readiness_pill_reads_ready_with_nothing_open(
+def test_title_reads_ready_with_nothing_open(
     sample_review_result: ReviewResult,
 ) -> None:
-    """A round with no findings renders the ready pill and an empty index."""
+    """A round with no findings renders Ready and an empty findings table."""
     body = _body_only(
         body=build_sticky_comment(result=_with(base=sample_review_result, findings=())),
     )
 
-    assert_that(body).contains("**✅ Ready** — no open findings")
-    assert_that(body).contains("### Open findings (0)")
+    assert_that(body).contains("## 🔎 Lintro Review — ✅ Ready")
+    assert_that(body).contains("### Findings ·")
     assert_that(body).contains("✅ Nothing open.")
 
 
-def test_readiness_pill_ignores_questions(
+def test_title_ignores_questions(
     sample_review_result: ReviewResult,
 ) -> None:
     """A question carries no severity, so it cannot block the PR."""
@@ -155,7 +154,7 @@ def test_readiness_pill_ignores_questions(
         ),
     )
 
-    assert_that(body).contains("**✅ Ready** — no open findings")
+    assert_that(body).contains("## 🔎 Lintro Review — ✅ Ready")
     assert_that(body).contains("❓ question")
 
 
@@ -176,7 +175,7 @@ def test_pill_counts_only_the_deciding_severity(
         ),
     )
 
-    assert_that(body).contains("**⛔ Blocked** — 2 open blockers")
+    assert_that(body).contains("## 🔎 Lintro Review — ⛔ Blocked")
 
 
 # --- delta line --------------------------------------------------------------
@@ -189,24 +188,21 @@ def test_round_one_renders_no_delta_line(
     body = _body_only(body=build_sticky_comment(result=sample_review_result))
 
     assert_that(body).does_not_contain("resolved ·")
-    assert_that(body).contains("round 1")
+    assert_that(body).contains("Round 1")
 
 
 def test_delta_line_counts_resolved_new_and_unchanged(
     sample_review_result: ReviewResult,
 ) -> None:
     """Round two reports what changed since round one."""
-    first = build_sticky_comment(
-        result=_with(
-            base=sample_review_result,
-            findings=(
-                _finding(title="Leak", line=10),
-                _finding(title="Slow loop", severity=Severity.P2, line=44),
-            ),
+    first_result = _with(
+        base=sample_review_result,
+        findings=(
+            _finding(title="Leak", line=10),
+            _finding(title="Slow loop", severity=Severity.P2, line=44),
         ),
-        head_sha="sha1",
     )
-
+    prior = advance_review_state(result=first_result, head_sha="sha1")
     second = build_sticky_comment(
         result=_with(
             base=sample_review_result,
@@ -215,13 +211,14 @@ def test_delta_line_counts_resolved_new_and_unchanged(
                 _finding(title="Unguarded divide", severity=Severity.P2, line=8),
             ),
         ),
-        prior_state=parse_review_state_v2(body=first),
+        prior_state=prior,
         head_sha="sha2",
     )
+    body = _body_only(body=second)
 
-    assert_that(_body_only(body=second)).contains(
-        "✔ 1 resolved · **1 new** · 1 unchanged since round 1",
-    )
+    assert_that(body).contains("2 open · 1 fixed this round")
+    assert_that(body).contains("| **new** |")
+    assert_that(body).contains("| ✔ fixed |")
 
 
 def test_delta_line_reports_regressions_separately(
@@ -232,25 +229,22 @@ def test_delta_line_reports_regressions_separately(
     Counting it as unchanged made the delta line contradict the ``↩ regressed``
     cell the open table shows immediately below it.
     """
-    first = build_sticky_comment(
-        result=_with(
-            base=sample_review_result,
-            findings=(
-                _finding(title="Leak"),
-                _finding(title="Slow loop", severity=Severity.P2, line=44),
-            ),
+    first_result = _with(
+        base=sample_review_result,
+        findings=(
+            _finding(title="Leak"),
+            _finding(title="Slow loop", severity=Severity.P2, line=44),
         ),
-        head_sha="sha1",
     )
-    fixed = build_sticky_comment(
+    after_first = advance_review_state(result=first_result, head_sha="sha1")
+    after_fixed = advance_review_state(
         result=_with(
             base=sample_review_result,
             findings=(_finding(title="Slow loop", severity=Severity.P2, line=44),),
         ),
-        prior_state=parse_review_state_v2(body=first),
+        prior_state=after_first,
         head_sha="sha2",
     )
-
     third = _body_only(
         body=build_sticky_comment(
             result=_with(
@@ -260,15 +254,11 @@ def test_delta_line_reports_regressions_separately(
                     _finding(title="Slow loop", severity=Severity.P2, line=44),
                 ),
             ),
-            prior_state=parse_review_state_v2(body=fixed),
+            prior_state=after_fixed,
             head_sha="sha3",
         ),
     )
 
-    assert_that(third).contains(
-        "✔ 0 resolved · **0 new** · ↩ 1 regressed · 1 unchanged since round 2",
-    )
-    # The line and the table agree on what happened to that finding.
     assert_that(third).contains("| ↩ regressed | 🔴 P1 | Leak |")
 
 
@@ -276,20 +266,17 @@ def test_delta_line_omits_the_regressed_clause_when_there_are_none(
     sample_review_result: ReviewResult,
 ) -> None:
     """The common case stays short — no "0 regressed" noise."""
-    first = build_sticky_comment(
-        result=_with(base=sample_review_result, findings=(_finding(title="Leak"),)),
-        head_sha="sha1",
-    )
-
+    first_result = _with(base=sample_review_result, findings=(_finding(title="Leak"),))
+    prior = advance_review_state(result=first_result, head_sha="sha1")
     second = _body_only(
         body=build_sticky_comment(
             result=_with(base=sample_review_result, findings=(_finding(title="Leak"),)),
-            prior_state=parse_review_state_v2(body=first),
+            prior_state=prior,
             head_sha="sha2",
         ),
     )
 
-    assert_that(second).contains("✔ 0 resolved · **0 new** · 1 unchanged since round 1")
+    assert_that(second).contains("| — | 🔴 P1 | Leak |")
     assert_that(second).does_not_contain("regressed")
 
 
@@ -317,11 +304,8 @@ def test_open_table_marks_new_and_carries_since_round(
     sample_review_result: ReviewResult,
 ) -> None:
     """The Δ column separates a newly raised finding from a carried one."""
-    first = build_sticky_comment(
-        result=_with(base=sample_review_result, findings=(_finding(title="Leak"),)),
-        head_sha="sha1",
-    )
-
+    first_result = _with(base=sample_review_result, findings=(_finding(title="Leak"),))
+    prior = advance_review_state(result=first_result, head_sha="sha1")
     second = _body_only(
         body=build_sticky_comment(
             result=_with(
@@ -331,7 +315,7 @@ def test_open_table_marks_new_and_carries_since_round(
                     _finding(title="Unguarded divide", severity=Severity.P2, line=8),
                 ),
             ),
-            prior_state=parse_review_state_v2(body=first),
+            prior_state=prior,
             head_sha="sha2",
         ),
     )
@@ -348,20 +332,17 @@ def test_open_table_marks_a_regressed_finding(
     sample_review_result: ReviewResult,
 ) -> None:
     """A finding that comes back after being fixed is flagged, not silently new."""
-    first = build_sticky_comment(
-        result=_with(base=sample_review_result, findings=(_finding(title="Leak"),)),
-        head_sha="sha1",
-    )
-    fixed = build_sticky_comment(
+    first_result = _with(base=sample_review_result, findings=(_finding(title="Leak"),))
+    after_first = advance_review_state(result=first_result, head_sha="sha1")
+    after_fixed = advance_review_state(
         result=_with(base=sample_review_result, findings=()),
-        prior_state=parse_review_state_v2(body=first),
+        prior_state=after_first,
         head_sha="sha2",
     )
-
     regressed = _body_only(
         body=build_sticky_comment(
             result=_with(base=sample_review_result, findings=(_finding(title="Leak"),)),
-            prior_state=parse_review_state_v2(body=fixed),
+            prior_state=after_fixed,
             head_sha="sha3",
         ),
     )
@@ -375,25 +356,22 @@ def test_resolved_questions_do_not_inflate_the_fixed_tile(
     sample_review_result: ReviewResult,
 ) -> None:
     """The fixed tile counts remediated findings, not questions that lapsed."""
-    first = build_sticky_comment(
-        result=_with(
-            base=sample_review_result,
-            findings=(
-                _finding(title="Leak"),
-                _finding(
-                    title="Is this intentional?",
-                    line=20,
-                    kind=FindingKind.QUESTION,
-                ),
+    first_result = _with(
+        base=sample_review_result,
+        findings=(
+            _finding(title="Leak"),
+            _finding(
+                title="Is this intentional?",
+                line=20,
+                kind=FindingKind.QUESTION,
             ),
         ),
-        head_sha="sha1",
     )
-
+    prior = advance_review_state(result=first_result, head_sha="sha1")
     second = _body_only(
         body=build_sticky_comment(
             result=_with(base=sample_review_result, findings=(_finding(title="Leak"),)),
-            prior_state=parse_review_state_v2(body=first),
+            prior_state=prior,
             head_sha="sha2",
         ),
     )
@@ -406,21 +384,17 @@ def test_resolved_table_stamps_the_fixing_commit(
     sample_review_result: ReviewResult,
 ) -> None:
     """A resolved finding is struck through and names where it was fixed."""
-    first = build_sticky_comment(
-        result=_with(base=sample_review_result, findings=(_finding(title="Leak"),)),
-        head_sha="0123456789abcdef",
-    )
-
+    first_result = _with(base=sample_review_result, findings=(_finding(title="Leak"),))
+    prior = advance_review_state(result=first_result, head_sha="0123456789abcdef")
     second = _body_only(
         body=build_sticky_comment(
             result=_with(base=sample_review_result, findings=()),
-            prior_state=parse_review_state_v2(body=first),
+            prior_state=prior,
             head_sha="fedcba9876543210",
         ),
     )
 
-    assert_that(second).contains("### ✔ Resolved (1)")
-    assert_that(second).contains("| 🔴 P1 | ~~Leak~~ | `fedcba9` · round 2 |")
+    assert_that(second).contains("| ✔ fixed | 🔴 P1 | ~~Leak~~ |")
 
 
 # --- summary and reasoning ---------------------------------------------------
@@ -476,9 +450,6 @@ def test_reasoning_section_carries_rubric_and_attention_files(
     assert_that(body).contains("The credential is evaluated at import time.")
     assert_that(body).contains("Every importer holds the secret.")
     assert_that(body).contains("**Files needing attention:** `src/example.py`")
-    # The rubric explains the pill and is rendered under it, not buried here.
-    reasoning_at = body.index("### Why it's blocked")
-    assert_that(body.index(VERDICT_RUBRIC_FINE_PRINT)).is_less_than(reasoning_at)
 
 
 # --- honesty and structure ---------------------------------------------------
@@ -498,33 +469,28 @@ def test_this_run_badges_lead_with_the_model_and_name_the_transport(
 
     assert_that(body).contains("**This run**")
     assert_that(body).contains(
-        "| model | est. cost | tokens in | tokens out |",
+        "| model | transport | est. cost | tokens in / out |",
     )
-    assert_that(body).contains(
-        "| `claude-sonnet-4-20250514` | $0.0500 | 1,000 | 200 |",
-    )
-    assert_that(body).contains(
-        "| transport | depth | files | checks | duration |",
-    )
-    assert_that(body).contains("| cli · subscription | 2 | 3 | 3 | 0s |")
+    assert_that(body).contains("`claude-sonnet-4-20250514`")
+    assert_that(body).contains("cli · subscription")
 
 
-def test_body_never_nests_details_more_than_one_level(
+def test_body_nests_details_only_inside_history(
     sample_review_result: ReviewResult,
 ) -> None:
-    """Nested collapsibles are what made the previous sticky unreadable."""
-    first = build_sticky_comment(
-        result=_with(base=sample_review_result, findings=(_finding(title="Leak"),)),
-        head_sha="sha1",
+    """History expanders nest one level; other collapsibles stay siblings."""
+    first_result = _with(
+        base=sample_review_result,
+        findings=(_finding(title="Leak"),),
     )
+    prior = advance_review_state(result=first_result, head_sha="sha1")
     finding = _finding(title="Unguarded divide", severity=Severity.P2, line=8)
-
     body = build_sticky_comment(
         result=_with(
             base=sample_review_result,
             findings=(_finding(title="Leak"), finding),
         ),
-        prior_state=parse_review_state_v2(body=first),
+        prior_state=prior,
         head_sha="sha2",
         checklist_display=ChecklistDisplay.ALL,
         inline_failure=InlinePostFailure(
@@ -533,7 +499,7 @@ def test_body_never_nests_details_more_than_one_level(
         ),
     )
 
-    assert_that(_max_details_depth(body=body)).is_equal_to(1)
+    assert_that(_max_details_depth(body=body)).is_less_than_or_equal_to(2)
 
 
 def test_history_collapsible_appears_once_and_only_after_round_one(
@@ -541,35 +507,31 @@ def test_history_collapsible_appears_once_and_only_after_round_one(
 ) -> None:
     """History is a single collapsible, absent while there is no history."""
     first = build_sticky_comment(result=sample_review_result, head_sha="sha1")
-    assert_that(_body_only(body=first)).does_not_contain("🕘 Run history")
-
+    assert_that(_body_only(body=first)).does_not_contain("🕘 History")
+    prior = advance_review_state(result=sample_review_result, head_sha="sha1")
     second = _body_only(
         body=build_sticky_comment(
             result=sample_review_result,
-            prior_state=parse_review_state_v2(body=first),
+            prior_state=prior,
             head_sha="sha2",
         ),
     )
 
-    assert_that(second.count("🕘 Run history")).is_equal_to(1)
-    assert_that(second).contains("🕘 Run history — 2 runs")
-    assert_that(second).contains("| Run | Commit | Verdict | Model | Open |")
-    assert_that(second).contains("**Round 1** · `sha1`")
+    assert_that(second.count("🕘 History")).is_equal_to(1)
+    assert_that(second).contains("### 🕘 History · 1 previous run")
+    assert_that(second).contains("<b>Round 1</b>")
 
 
 def test_fix_all_panel_is_scoped_to_all_open_findings(
     sample_review_result: ReviewResult,
 ) -> None:
     """The panel title and the prompt's first line both restate the scope."""
-    first = build_sticky_comment(
-        result=_with(base=sample_review_result, findings=(_finding(title="Leak"),)),
-        head_sha="sha1",
-    )
-
+    first_result = _with(base=sample_review_result, findings=(_finding(title="Leak"),))
+    prior = advance_review_state(result=first_result, head_sha="sha1")
     second = _body_only(
         body=build_sticky_comment(
             result=_with(base=sample_review_result, findings=(_finding(title="Leak"),)),
-            prior_state=parse_review_state_v2(body=first),
+            prior_state=prior,
             head_sha="sha2",
         ),
     )
@@ -639,7 +601,7 @@ def test_warning_row_precedes_the_open_findings_table(
     )
 
     assert_that(body.index("could not be posted as an inline")).is_less_than(
-        body.index("### Open findings"),
+        body.index("### Findings ·"),
     )
 
 
@@ -737,11 +699,20 @@ def test_oldest_history_is_pruned_before_any_finding(
             low = middle + 1
     crossing = low
 
-    # At the crossing some history is gone but the newest rounds remain: a
-    # single extra finding can cost more than one round's worth of characters,
-    # so the drop is not necessarily exactly one.
+    # History may move to the archive comment before in-comment prune
+    # fires. Either way the primary stays under GitHub's cap.
     assert_that(rounds_shown(count=crossing)).is_less_than(_PRIOR_ROUNDS)
-    assert_that(rounds_shown(count=crossing)).is_greater_than(0)
+    crossing_body = _render_with_findings(
+        base=sample_review_result,
+        count=crossing,
+        prior_state=prior_state,
+    )
+    crossing_rendered = _body_only(body=crossing_body)
+    assert_that(len(crossing_body)).is_less_than_or_equal_to(GITHUB_COMMENT_HARD_LIMIT)
+    assert_that(crossing_rendered).contains("### Findings ·")
+    if rounds_shown(count=crossing) == 0:
+        assert_that(crossing_rendered).contains("History")
+        return
 
     saw_partial_history = False
     for count in range(max(crossing - 2, 1), crossing + 4):
@@ -763,7 +734,7 @@ def test_oldest_history_is_pruned_before_any_finding(
             assert_that(rendered).contains("history truncated")
         if shown:
             # History still had rows to shed, so no finding may be dropped.
-            assert_that(rendered).contains(f"### Open findings ({count})")
+            assert_that(rendered).contains("### Findings ·")
             assert_that(rendered).does_not_contain("more open findings not listed")
         if 0 < len(shown) < _PRIOR_ROUNDS:
             saw_partial_history = True
@@ -794,7 +765,7 @@ def test_comment_stays_under_the_hard_limit_with_huge_finding_sets(
     assert_that(len(body)).is_less_than_or_equal_to(GITHUB_COMMENT_HARD_LIMIT)
     assert_that(body).contains(STICKY_MARKER)
     rendered = _body_only(body=body)
-    assert_that(rendered).contains("### Open findings (400)")
+    assert_that(rendered).contains("### Findings ·")
     assert_that(rendered).contains("more open findings not listed")
     # Never a verdict with no substance: at least one finding is always listed.
     assert_that(rendered).contains("| 🟠 P2 |")

--- a/tests/unit/ai/review/test_github_sticky_state.py
+++ b/tests/unit/ai/review/test_github_sticky_state.py
@@ -1,4 +1,4 @@
-"""Sticky-comment integration tests for review state schema v2 (#1906)."""
+"""Sticky-comment integration tests for review state after #2154/#2157."""
 
 from __future__ import annotations
 
@@ -15,12 +15,11 @@ from lintro.ai.review.github_constants import (
     MAX_STORED_RUNS,
     STATE_MARKER_PREFIX,
     STATE_MARKER_SUFFIX,
-    STATE_VERSION,
 )
 from lintro.ai.review.github_errors import format_error_comment
 from lintro.ai.review.github_sticky import (
+    advance_review_state,
     build_sticky_comment,
-    parse_review_state,
     parse_review_state_v2,
 )
 from lintro.ai.review.models.finding_record import FindingRecord
@@ -29,6 +28,7 @@ from lintro.ai.review.models.review_finding import ReviewFinding, Severity
 from lintro.ai.review.models.review_result import ReviewResult
 from lintro.ai.review.models.review_state import ReviewState
 from lintro.ai.review.models.run_record import RunRecord
+from lintro.ai.review.review_state_codec import decode_state, legacy_state_block
 
 
 def _finding(
@@ -61,15 +61,17 @@ def _with_findings(
     return replace(base, findings=findings)
 
 
-def test_sticky_state_block_is_version_two(
+def test_sticky_writes_no_state_blob(
     sample_review_result: ReviewResult,
 ) -> None:
-    """A fresh sticky comment writes a v2 blob with runs and findings."""
+    """A fresh sticky is rendering only; state lives in the artifact."""
     body = build_sticky_comment(result=sample_review_result, head_sha="abc123")
+    state = advance_review_state(
+        result=sample_review_result,
+        head_sha="abc123",
+    )
 
-    state = parse_review_state_v2(body=body)
-
-    assert_that(state.version).is_equal_to(STATE_VERSION)
+    assert_that(body).does_not_contain(STATE_MARKER_PREFIX)
     assert_that(state.runs).is_length(1)
     assert_that(state.runs[0].round).is_equal_to(1)
     assert_that(state.runs[0].sha).is_equal_to("abc123")
@@ -80,14 +82,13 @@ def test_sticky_records_transport_auth_and_cost_basis(
     sample_review_result: ReviewResult,
 ) -> None:
     """Transport, auth mode, and cost_basis are persisted with the run record."""
-    body = build_sticky_comment(
+    state = advance_review_state(
         result=sample_review_result,
         transport="cli",
         auth_mode="subscription",
         cost_basis="unpriceable",
     )
-
-    run = parse_review_state_v2(body=body).runs[0]
+    run = state.runs[0]
 
     assert_that(run.transport).is_equal_to("cli")
     assert_that(run.auth_mode).is_equal_to("subscription")
@@ -103,49 +104,41 @@ def test_sticky_verdict_is_derived_from_open_severities(
     sample_review_result: ReviewResult,
 ) -> None:
     """The recorded verdict follows the open findings, not the model."""
-    blocked = build_sticky_comment(
+    blocked = advance_review_state(
         result=_with_findings(
             base=sample_review_result,
             findings=(_finding(title="Leak"),),
         ),
     )
-    ready = build_sticky_comment(
+    ready = advance_review_state(
         result=_with_findings(base=sample_review_result, findings=()),
     )
 
-    assert_that(parse_review_state_v2(body=blocked).runs[0].verdict).is_equal_to(
-        ReviewVerdict.BLOCKED,
-    )
-    assert_that(parse_review_state_v2(body=ready).runs[0].verdict).is_equal_to(
-        ReviewVerdict.READY,
-    )
+    assert_that(blocked.runs[0].verdict).is_equal_to(ReviewVerdict.BLOCKED)
+    assert_that(ready.runs[0].verdict).is_equal_to(ReviewVerdict.READY)
 
 
 def test_second_round_carries_and_resolves_findings(
     sample_review_result: ReviewResult,
 ) -> None:
     """A follow-up round carries repeats and resolves disappeared findings."""
-    first = build_sticky_comment(
-        result=_with_findings(
-            base=sample_review_result,
-            findings=(
-                _finding(title="Leak"),
-                _finding(title="Slow loop", line=44, severity=Severity.P2),
-            ),
+    first_result = _with_findings(
+        base=sample_review_result,
+        findings=(
+            _finding(title="Leak"),
+            _finding(title="Slow loop", line=44, severity=Severity.P2),
         ),
-        head_sha="sha1",
     )
-
-    second = build_sticky_comment(
+    prior = advance_review_state(result=first_result, head_sha="sha1")
+    state = advance_review_state(
         result=_with_findings(
             base=sample_review_result,
             findings=(_finding(title="Leak", line=15),),
         ),
-        prior_state=parse_review_state_v2(body=first),
+        prior_state=prior,
         head_sha="sha2",
     )
 
-    state = parse_review_state_v2(body=second)
     assert_that(state.runs).is_length(2)
     assert_that(state.runs[-1].round).is_equal_to(2)
     assert_that(state.open_findings).is_length(1)
@@ -169,14 +162,12 @@ def test_sticky_migrates_a_v1_state_blob(
         },
     )
     prior_body = f"## old\n\n{STATE_MARKER_PREFIX} {legacy} {STATE_MARKER_SUFFIX}"
-
-    body = build_sticky_comment(
+    prior = parse_review_state_v2(body=prior_body)
+    state = advance_review_state(
         result=sample_review_result,
-        prior_state=parse_review_state_v2(body=prior_body),
+        prior_state=prior,
     )
 
-    state = parse_review_state_v2(body=body)
-    assert_that(state.version).is_equal_to(STATE_VERSION)
     assert_that([run.round for run in state.runs]).is_equal_to([1, 2, 3])
     assert_that(state.findings).is_not_empty()
 
@@ -185,14 +176,17 @@ def test_legacy_prior_runs_argument_still_works(
     sample_review_result: ReviewResult,
 ) -> None:
     """The ``prior_runs`` compatibility path keeps cumulative telemetry."""
-    first = build_sticky_comment(result=sample_review_result)
-
+    first = advance_review_state(result=sample_review_result)
     body = build_sticky_comment(
         result=sample_review_result,
-        prior_runs=parse_review_state(body=first),
+        prior_runs=[run.to_dict() for run in first.runs],
+    )
+    state = advance_review_state(
+        result=sample_review_result,
+        prior_runs=[run.to_dict() for run in first.runs],
     )
 
-    state = parse_review_state_v2(body=body)
+    assert_that(body).contains("### 🕘 History")
     assert_that(state.runs).is_length(2)
     assert_that([run.round for run in state.runs]).is_equal_to([1, 2])
 
@@ -200,73 +194,57 @@ def test_legacy_prior_runs_argument_still_works(
 def test_legacy_prior_runs_with_multiple_raw_v1_dicts_renumbers_positionally(
     sample_review_result: ReviewResult,
 ) -> None:
-    """Raw v1 dicts (no ``round`` key) trigger the positional-renumber branch.
-
-    ``test_legacy_prior_runs_argument_still_works`` passes ``prior_runs``
-    already carrying a ``round`` key (parsed from a v2 comment), so it never
-    exercises the heuristic that fires when every parsed run defaults to
-    round 1 — the actual shape of a genuine v1 blob's runs.
-    """
+    """Raw v1 dicts (no ``round`` key) trigger the positional-renumber branch."""
     raw_v1_runs = [
         {"model": "claude", "total": 100, "cost": 0.01},
         {"model": "claude", "total": 200, "cost": 0.02},
     ]
-
-    body = build_sticky_comment(
+    state = advance_review_state(
         result=sample_review_result,
         prior_runs=raw_v1_runs,
     )
 
-    state = parse_review_state_v2(body=body)
     assert_that([run.round for run in state.runs]).is_equal_to([1, 2, 3])
 
 
 def test_error_comment_preserves_finding_history(
     sample_review_result: ReviewResult,
 ) -> None:
-    """A failed round re-emits the prior state instead of resetting it."""
-    first = build_sticky_comment(
+    """A failed round re-renders the prior board instead of resetting it."""
+    prior_state = advance_review_state(
         result=_with_findings(
             base=sample_review_result,
             findings=(_finding(title="Leak"),),
         ),
         head_sha="sha1",
     )
-    prior_state = parse_review_state_v2(body=first)
-
     body = format_error_comment(
         error=RuntimeError("boom"),
         provider="anthropic",
         prior_state=prior_state,
     )
 
-    recovered = parse_review_state_v2(body=body)
-    assert_that(recovered.runs).is_length(1)
-    assert_that(recovered.open_findings).is_length(1)
-    assert_that(recovered.open_findings[0].status).is_equal_to(FindingStatus.OPEN)
+    assert_that(body).contains("## 🔎 Lintro Review")
+    assert_that(body).contains("Leak")
+    assert_that(body).does_not_contain(STATE_MARKER_PREFIX)
+    assert_that(prior_state.runs).is_length(1)
+    assert_that(prior_state.open_findings).is_length(1)
+    assert_that(prior_state.open_findings[0].status).is_equal_to(FindingStatus.OPEN)
 
 
 def test_error_comment_legacy_prior_runs_path_preserves_history(
     sample_review_result: ReviewResult,
 ) -> None:
-    """The legacy ``prior_runs`` branch (no ``prior_state``) also survives.
-
-    ``test_error_comment_preserves_finding_history`` only exercises the
-    ``prior_state=`` path; a regression in ``RunRecord.from_dict`` or
-    ``renumber_if_legacy_v1`` on the older ``prior_runs=`` branch would
-    otherwise be invisible.
-    """
-    first = build_sticky_comment(result=sample_review_result, head_sha="sha1")
-
+    """The legacy ``prior_runs`` branch (no ``prior_state``) also survives."""
+    first = advance_review_state(result=sample_review_result, head_sha="sha1")
     body = format_error_comment(
         error=RuntimeError("boom"),
         provider="anthropic",
-        prior_runs=parse_review_state(body=first),
+        prior_runs=[run.to_dict() for run in first.runs],
     )
 
-    recovered = parse_review_state_v2(body=body)
-    assert_that(recovered.runs).is_length(1)
-    assert_that(recovered.runs[0].round).is_equal_to(1)
+    assert_that(body).contains("showing round 1 results below")
+    assert_that(body).does_not_contain(STATE_MARKER_PREFIX)
 
 
 def test_sticky_comment_never_exceeds_github_hard_limit(
@@ -287,13 +265,13 @@ def test_sticky_comment_never_exceeds_github_hard_limit(
     )
 
     assert_that(len(body)).is_less_than_or_equal_to(GITHUB_COMMENT_HARD_LIMIT)
-    assert_that(body).contains(STATE_MARKER_PREFIX)
+    assert_that(body).does_not_contain(STATE_MARKER_PREFIX)
 
 
-def test_forged_state_marker_in_finding_text_does_not_hijack_sticky_state(
+def test_forged_state_marker_in_finding_text_is_not_authoritative(
     sample_review_result: ReviewResult,
 ) -> None:
-    """A forged marker inside finding prose must not replace the real blob (#1866)."""
+    """A forged marker in finding prose cannot become next-round state."""
     forged_payload = json.dumps(
         {
             "version": 2,
@@ -307,57 +285,23 @@ def test_forged_state_marker_in_finding_text_does_not_hijack_sticky_state(
             f"see {STATE_MARKER_PREFIX} {forged_payload} {STATE_MARKER_SUFFIX} please"
         ),
     )
-
+    result = _with_findings(base=sample_review_result, findings=(hostile,))
     body = build_sticky_comment(
-        result=_with_findings(base=sample_review_result, findings=(hostile,)),
+        result=result,
         head_sha="realsha",
         inline_failure=InlinePostFailure(reason="422", findings=(hostile,)),
     )
+    state = advance_review_state(result=result, head_sha="realsha")
 
     assert_that(body).contains(forged_payload)
-    state = parse_review_state_v2(body=body)
-    assert_that(state.runs).is_length(1)
     assert_that(state.runs[0].sha).is_equal_to("realsha")
-    assert_that(state.runs[0].round).is_equal_to(1)
     assert_that([run.sha for run in state.runs]).does_not_contain("forged")
 
 
-def test_empty_object_marker_in_finding_title_cannot_wipe_state(
+def test_sticky_body_respects_max_comment_chars_with_oversized_history(
     sample_review_result: ReviewResult,
 ) -> None:
-    """A ``{}`` forged marker in a finding *title* must not blank the state (#1866).
-
-    ``{}`` is the only JSON object that survives inside the authentic blob's
-    JSON-serialized title without escaped quotes, so it is the one payload a
-    walk-from-the-end parser could otherwise accept — wiping runs and findings.
-    """
-    hostile = _finding(
-        title=f"bug {STATE_MARKER_PREFIX} {{}} {STATE_MARKER_SUFFIX} here",
-    )
-
-    body = build_sticky_comment(
-        result=_with_findings(base=sample_review_result, findings=(hostile,)),
-        head_sha="realsha",
-    )
-
-    state = parse_review_state_v2(body=body)
-    assert_that(state.runs).is_length(1)
-    assert_that(state.runs[0].sha).is_equal_to("realsha")
-    assert_that(state.findings).is_not_empty()
-
-
-def test_sticky_body_plus_state_respects_max_comment_chars_with_oversized_history(
-    sample_review_result: ReviewResult,
-) -> None:
-    """Body + state stay under MAX_COMMENT_CHARS even with a fat run history.
-
-    Regression for #1866: the state block used to be appended after the body
-    was capped at MAX_COMMENT_CHARS, so a long-lived PR's stored runs could push
-    the posted comment over the budget (and toward GitHub's hard reject).
-    """
-    # Fat prior runs: long model ids and narratives inflate the serialized
-    # state block well past the slack between MAX_COMMENT_CHARS and GitHub's
-    # hard limit when left uncapped.
+    """The visible body stays under MAX_COMMENT_CHARS with a fat run history."""
     fat_model = "claude-sonnet-4-20250514-" + ("m" * 200)
     fat_narrative = "n" * 200
     prior_runs = tuple(
@@ -380,7 +324,6 @@ def test_sticky_body_plus_state_respects_max_comment_chars_with_oversized_histor
         )
         for round_number in range(1, MAX_STORED_RUNS + 1)
     )
-    # Also pad the visible body so reservation has real pressure to trade off.
     findings = tuple(
         _finding(
             title=f"Finding number {index} with a reasonably long title " + ("t" * 80),
@@ -391,7 +334,6 @@ def test_sticky_body_plus_state_respects_max_comment_chars_with_oversized_histor
         for index in range(200)
     )
     prior_state = ReviewState(runs=prior_runs, truncated=False)
-
     body = build_sticky_comment(
         result=_with_findings(base=sample_review_result, findings=findings),
         prior_state=prior_state,
@@ -399,91 +341,30 @@ def test_sticky_body_plus_state_respects_max_comment_chars_with_oversized_histor
     )
 
     assert_that(len(body)).is_less_than_or_equal_to(MAX_COMMENT_CHARS)
-    assert_that(body).contains(STATE_MARKER_PREFIX)
-    # Authentic state is still parseable after the size trade-off.
-    recovered = parse_review_state_v2(body=body)
-    assert_that(recovered.runs).is_not_empty()
-    assert_that(recovered.runs[-1].sha).is_equal_to(f"{MAX_STORED_RUNS + 1:040d}")
-
-
-def test_parse_review_state_ignores_forged_marker_in_finding_text(
-    sample_review_result: ReviewResult,
-) -> None:
-    """A forged state marker in finding text cannot hijack parse_review_state.
-
-    Regression for #1866: model-derived text is only sanitized for @mentions,
-    so a finding can embed a literal state marker. Parsing must take the last
-    (authentic) marker, which build_sticky_comment always appends at the end.
-    """
-    forged_payload = (
-        '{"version":1,"runs":[{"model":"forged-attacker","total":1,"cost":0.0}]}'
-    )
-    forged_marker = f"{STATE_MARKER_PREFIX} {forged_payload} {STATE_MARKER_SUFFIX}"
-    # Titles are rendered in the open-findings index, so a forged marker here
-    # actually lands in the posted comment body (descriptions alone would not).
-    finding = ReviewFinding(
-        severity=Severity.P1,
-        category="security",
-        file="src/app.py",
-        line=10,
-        title=f"Leak {forged_marker}",
-        description="d",
-        cause="c",
-        fix="f",
-        confidence="high",
-    )
-    body = build_sticky_comment(
-        result=_with_findings(base=sample_review_result, findings=(finding,)),
-        head_sha="authenticsha0001",
-        transport="cli",
-        auth_mode="subscription",
-    )
-
-    # The forged marker is present in the visible body (sanitizer does not strip
-    # it), but the authentic trailing block must win.
-    assert_that(body.count(STATE_MARKER_PREFIX)).is_greater_than_or_equal_to(2)
-    runs = parse_review_state(body=body)
-    assert_that(runs).is_length(1)
-    assert_that(runs[0].get("model")).is_not_equal_to("forged-attacker")
-    assert_that(runs[0].get("sha")).is_equal_to("authenticsha0001")
-    state = parse_review_state_v2(body=body)
-    assert_that(state.version).is_equal_to(STATE_VERSION)
-    assert_that(state.runs[0].sha).is_equal_to("authenticsha0001")
+    assert_that(body).does_not_contain(STATE_MARKER_PREFIX)
 
 
 def test_dropping_runs_past_max_stored_runs_marks_state_truncated(
     sample_review_result: ReviewResult,
 ) -> None:
-    """The state is marked truncated when the run-count cap drops history.
-
-    ``prune_state_to_fit`` sets ``truncated`` when it prunes for size, but the
-    ``[-MAX_STORED_RUNS:]`` slice in ``build_sticky_comment`` is a second,
-    independent place history can be dropped. Both must set the flag.
-    """
+    """The state is marked truncated when the run-count cap drops history."""
     prior_runs = tuple(
         RunRecord(round=round_number, sha=f"sha{round_number}")
         for round_number in range(1, MAX_STORED_RUNS + 1)
     )
     prior_state = ReviewState(runs=prior_runs, truncated=False)
-
-    body = build_sticky_comment(
+    state = advance_review_state(
         result=sample_review_result,
         prior_state=prior_state,
         head_sha=f"sha{MAX_STORED_RUNS + 1}",
     )
 
-    state = parse_review_state_v2(body=body)
     assert_that(state.runs).is_length(MAX_STORED_RUNS)
     assert_that(state.truncated).is_true()
 
 
 def test_error_comment_prunes_a_near_limit_prior_state() -> None:
-    """format_error_comment must prune, not just append, an oversized state.
-
-    A valid prior state can nearly fill GitHub's comment cap on its own;
-    appending it to the error body unpruned can push the total over the
-    limit that ``build_sticky_comment`` otherwise always respects.
-    """
+    """format_error_comment must stay under the comment budget."""
     findings = tuple(
         FindingRecord(
             fingerprint=f"{index:016d}",
@@ -499,7 +380,6 @@ def test_error_comment_prunes_a_near_limit_prior_state() -> None:
         for index in range(200)
     )
     prior_state = ReviewState(runs=(RunRecord(round=1, sha="sha1"),), findings=findings)
-
     body = format_error_comment(
         error=RuntimeError("boom"),
         provider="anthropic",
@@ -509,58 +389,35 @@ def test_error_comment_prunes_a_near_limit_prior_state() -> None:
     assert_that(len(body)).is_less_than_or_equal_to(MAX_COMMENT_CHARS)
 
 
-def test_unshrinkable_state_block_is_dropped_not_oversized(
-    sample_review_result: ReviewResult,
-) -> None:
-    """A state block that cannot fit even pruned is dropped entirely (#1866).
-
-    Pruning floors at one run with unshortened fields; a pathological record
-    must never push the posted comment past the hard limit — the last resort
-    is posting without state (cross-run tracking resets next round).
-    """
-    forged = (
-        f"{STATE_MARKER_PREFIX} "
-        '{"version": 2, "runs": [{"round": 9, "sha": "forged"}], "findings": []} '
-        f"{STATE_MARKER_SUFFIX}"
+def test_leftover_blob_still_decodes_for_migration() -> None:
+    """A leftover v2 blob remains readable for one-time sticky migration."""
+    state = ReviewState(
+        runs=(RunRecord(round=1, sha="realsha", model="claude"),),
+        findings=(
+            FindingRecord(
+                fingerprint="a" * 16,
+                title="Leak",
+                severity=Severity.P2,
+                status=FindingStatus.OPEN,
+                since_round=1,
+            ),
+        ),
     )
-    monster = _finding(
-        title="t" * (GITHUB_COMMENT_HARD_LIMIT + 10_000) + " " + forged,
-    )
+    body = f"## Review{legacy_state_block(state=state)}"
+    decoded = decode_state(body=body)
 
-    body = build_sticky_comment(
-        result=_with_findings(base=sample_review_result, findings=(monster,)),
-        head_sha="realsha",
-    )
-
-    assert_that(len(body)).is_less_than_or_equal_to(MAX_COMMENT_CHARS)
-    # Normal pruning absorbed the monster; the authentic block still wins
-    # over the forged marker embedded in the visible prose.
-    state = parse_review_state_v2(body=body)
-    assert_that([run.sha for run in state.runs]).does_not_contain("forged")
-    assert_that([run.sha for run in state.runs]).contains("realsha")
+    assert_that(decoded.runs[0].sha).is_equal_to("realsha")
+    assert_that(decoded.findings).is_length(1)
 
 
-def test_floor_overflow_falls_back_to_empty_authentic_block() -> None:
-    """When even the pruned floor cannot fit, an empty authentic block posts.
-
-    Exercises the last-resort branch of ``_fit_body_with_state`` directly with
-    a run field pruning cannot shorten: the total stays under the cap and the
-    walk still finds an authentic (empty) block last, so a forged marker in
-    body prose can never become the state (#1866).
-    """
+def test_floor_overflow_no_longer_appends_a_state_block() -> None:
+    """``_fit_body_with_state`` is leftover; new stickies append nothing."""
     from lintro.ai.review.github_sticky import _fit_body_with_state
-    from lintro.ai.review.models.run_record import RunRecord
 
     monster_run = RunRecord(round=1, sha="realsha", narrative="n" * 70_000)
     state = ReviewState(runs=(monster_run,), findings=(), truncated=False)
-    forged = (
-        f"{STATE_MARKER_PREFIX} "
-        '{"version": 2, "runs": [{"round": 9, "sha": "forged"}], "findings": []} '
-        f"{STATE_MARKER_SUFFIX}"
-    )
-
     body = _fit_body_with_state(
-        assemble=lambda *, limits: f"visible body {forged}",
+        assemble=lambda *, limits: "visible body",
         prior_run_count=0,
         open_count=0,
         resolved_count=0,
@@ -568,6 +425,4 @@ def test_floor_overflow_falls_back_to_empty_authentic_block() -> None:
     )
 
     assert_that(len(body)).is_less_than_or_equal_to(MAX_COMMENT_CHARS)
-    recovered = parse_review_state_v2(body=body)
-    assert_that(recovered.runs).is_empty()
-    assert_that(recovered.truncated).is_true()
+    assert_that(body).does_not_contain(STATE_MARKER_PREFIX)

--- a/tests/unit/ai/review/test_inline_posting_1911.py
+++ b/tests/unit/ai/review/test_inline_posting_1911.py
@@ -15,9 +15,11 @@ from assertpy import assert_that
 
 from lintro.ai.integrations.github_pr import GitHubPRReporter
 from lintro.ai.review.github import post_review_to_github
-from lintro.ai.review.github_sticky import build_sticky_comment
+from lintro.ai.review.github_constants import STICKY_MARKER
+from lintro.ai.review.github_sticky import advance_review_state
 from lintro.ai.review.models.review_result import ReviewResult
 from lintro.ai.review.models.suggested_change import SuggestedChange
+from lintro.ai.review.review_state_codec import legacy_state_block
 
 _TEST_TOKEN = (
     "ghp_test_fixture_token"  # noqa: S105  # nosec B105 — fake test fixture token
@@ -43,6 +45,12 @@ def _reporter() -> MagicMock:
     reporter.repo = "owner/name"
     reporter.pr_number = 7
     return reporter
+
+
+def _prior_sticky(*, result: ReviewResult, head_sha: str) -> str:
+    """Render a leftover v2 sticky so posting can migrate prior state."""
+    state = advance_review_state(result=result, head_sha=head_sha)
+    return STICKY_MARKER + legacy_state_block(state=state)
 
 
 def _with_change(
@@ -142,7 +150,7 @@ def test_round_two_scopes_suggestions_to_the_new_commits(
     )
     reporter.find_issue_comment.return_value = (
         42,
-        build_sticky_comment(result=result, head_sha="aaa111"),
+        _prior_sticky(result=result, head_sha="aaa111"),
     )
     # This round only touched line 40, so the finding's line is old ground.
     reporter.fetch_compare_lines.return_value = {"src/main.py": {40}}
@@ -186,7 +194,7 @@ def test_carried_over_finding_falls_back_to_mode_b(
     # new commits did touch, so only the carried-over rule can reject it.
     reporter.find_issue_comment.return_value = (
         42,
-        build_sticky_comment(result=result, head_sha="aaa111"),
+        _prior_sticky(result=result, head_sha="aaa111"),
     )
     reporter.fetch_compare_lines.return_value = {"src/main.py": {9, 10, 11}}
 
@@ -208,7 +216,7 @@ def test_round_two_finding_new_to_this_round_keeps_mode_a(
     )
     reporter.find_issue_comment.return_value = (
         42,
-        build_sticky_comment(result=prior, head_sha="aaa111"),
+        _prior_sticky(result=prior, head_sha="aaa111"),
     )
     reporter.fetch_compare_lines.return_value = {"src/main.py": {9, 10, 11}}
     # Same location, different finding — round 2 sees it for the first time.
@@ -236,7 +244,7 @@ def test_prior_round_without_a_recorded_sha_falls_back_to_mode_b(
     # round's diff.
     reporter.find_issue_comment.return_value = (
         42,
-        build_sticky_comment(result=result, head_sha=""),
+        _prior_sticky(result=result, head_sha=""),
     )
 
     post_review_to_github(result=result, reporter=reporter)

--- a/tests/unit/ai/review/test_mock_parity_1951.py
+++ b/tests/unit/ai/review/test_mock_parity_1951.py
@@ -30,7 +30,7 @@ from lintro.ai.review.github_render import (
     format_finding_comment,
 )
 from lintro.ai.review.github_review_body import REVIEW_BODY_FOOTER
-from lintro.ai.review.github_sticky import build_sticky_comment, parse_review_state_v2
+from lintro.ai.review.github_sticky import advance_review_state, build_sticky_comment
 from lintro.ai.review.inline_fix import plan_inline_fix
 from lintro.ai.review.models.finding_record import FindingRecord
 from lintro.ai.review.models.review_finding import ReviewFinding, Severity
@@ -39,7 +39,7 @@ from lintro.ai.review.models.review_state import ReviewState
 from lintro.ai.review.models.review_summary import ReviewSummary
 from lintro.ai.review.models.run_record import RunRecord
 from lintro.ai.review.models.suggested_change import SuggestedChange
-from lintro.ai.review.review_state_codec import render_state_block
+from lintro.ai.review.review_state_codec import legacy_state_block
 from lintro.ai.review.verdict import VERDICT_RUBRIC_FINE_PRINT
 
 
@@ -87,8 +87,7 @@ def test_open_finding_title_links_to_its_inline_comment(
 ) -> None:
     """A finding whose thread is known renders its title as a link to it."""
     result = _with(base=sample_review_result, findings=(_finding(),))
-    first = build_sticky_comment(result=result, head_sha="sha1")
-    state = parse_review_state_v2(body=first)
+    state = advance_review_state(result=result, head_sha="sha1")
     key = state.findings[0].key
 
     body = _body_only(
@@ -129,7 +128,7 @@ def test_open_finding_renders_unlinked_without_repo_context(
 ) -> None:
     """A known comment id is not enough: the URL also needs repo and PR."""
     result = _with(base=sample_review_result, findings=(_finding(),))
-    state = parse_review_state_v2(body=build_sticky_comment(result=result))
+    state = advance_review_state(result=result)
 
     body = _body_only(
         body=build_sticky_comment(
@@ -156,7 +155,7 @@ def test_a_model_written_bracket_cannot_break_out_of_the_link(
         base=sample_review_result,
         findings=(_finding(title=hostile),),
     )
-    state = parse_review_state_v2(body=build_sticky_comment(result=result))
+    state = advance_review_state(result=result)
 
     body = _body_only(
         body=build_sticky_comment(
@@ -187,26 +186,21 @@ def test_history_row_reports_open_after_the_round_and_what_it_fixed(
     sample_review_result: ReviewResult,
 ) -> None:
     """Round two fixed one finding and left one open; the table says so."""
-    first = build_sticky_comment(
-        result=_with(
-            base=sample_review_result,
-            findings=(_finding(title="Leak"), _finding(title="Race", line=20)),
-        ),
-        head_sha="sha1",
+    first_result = _with(
+        base=sample_review_result,
+        findings=(_finding(title="Leak"), _finding(title="Race", line=20)),
     )
-
+    prior = advance_review_state(result=first_result, head_sha="sha1")
     second = _body_only(
         body=build_sticky_comment(
             result=_with(base=sample_review_result, findings=(_finding(title="Leak"),)),
-            prior_state=parse_review_state_v2(body=first),
+            prior_state=prior,
             head_sha="sha2",
         ),
     )
 
-    assert_that(second).contains("| Open | Fixed |")
-    # Round 2: one still open, one fixed. The raised count was also one, so the
-    # fixed column is what proves the round is being reported honestly.
-    assert_that(second).contains("| 1 | 1 |")
+    assert_that(second).contains("1 open · 1 fixed this round")
+    assert_that(second).contains("| ✔ fixed | 🔴 P1 | ~~Race~~ |")
 
 
 def test_history_row_falls_back_for_state_without_the_new_counts(
@@ -225,8 +219,9 @@ def test_history_row_falls_back_for_state_without_the_new_counts(
         ),
     )
 
-    # Legacy round 1: three findings raised, fixed count unknown.
-    assert_that(body).contains("| 3 | — |")
+    # Legacy round 1: three findings raised (p1+p2), fixed count treated as 0.
+    assert_that(body).contains("<b>Round 1</b>")
+    assert_that(body).contains("3 left open")
 
 
 def test_legacy_run_payload_without_the_new_fields_loads() -> None:
@@ -281,27 +276,24 @@ def test_history_recap_renders_the_rounds_narrative(
     sample_review_result: ReviewResult,
 ) -> None:
     """The model's own account of a round beats a severity tally."""
-    first = build_sticky_comment(
-        result=_with(
-            base=sample_review_result,
-            findings=(_finding(),),
-            pr_summary=ReviewSummary(
-                headline="Adds a fail-open default to the auth path.",
-                walkthrough=(),
-            ),
+    first_result = _with(
+        base=sample_review_result,
+        findings=(_finding(),),
+        pr_summary=ReviewSummary(
+            headline="Adds a fail-open default to the auth path.",
+            walkthrough=(),
         ),
-        head_sha="sha1",
     )
-
+    prior = advance_review_state(result=first_result, head_sha="sha1")
     second = _body_only(
         body=build_sticky_comment(
             result=_with(base=sample_review_result, findings=(_finding(),)),
-            prior_state=parse_review_state_v2(body=first),
+            prior_state=prior,
             head_sha="sha2",
         ),
     )
 
-    assert_that(second).contains("**Round 1** · `sha1`")
+    assert_that(second).contains("<b>Round 1</b>")
     assert_that(second).contains("Adds a fail-open default to the auth path.")
 
 
@@ -321,7 +313,8 @@ def test_history_recap_falls_back_to_counts_without_a_narrative(
         ),
     )
 
-    assert_that(body).contains("🔴 1 · 🟠 2 · 🟡 3")
+    assert_that(body).contains("<b>Round 1</b>")
+    assert_that(body).contains("6 left open")
 
 
 @pytest.mark.parametrize(
@@ -356,12 +349,8 @@ def test_narrative_keeps_only_the_first_sentence(
     expected: str,
 ) -> None:
     """A recap is one line; the rest of a paragraph is not persisted."""
-    body = build_sticky_comment(
-        result=_with(base=sample_review_result, findings=(), summary=summary),
-        head_sha="sha1",
-    )
-
-    stored = parse_review_state_v2(body=body).runs[-1]
+    result = _with(base=sample_review_result, findings=(), summary=summary)
+    stored = advance_review_state(result=result, head_sha="sha1").runs[-1]
 
     assert_that(stored.narrative).is_equal_to(expected)
 
@@ -400,7 +389,7 @@ def test_regressed_thread_titles_say_regressed(
 ) -> None:
     """The fresh thread's title carries the suffix, not just a provenance note."""
     finding = _finding()
-    prior_body = STICKY_MARKER + render_state_block(
+    prior_body = STICKY_MARKER + legacy_state_block(
         state=_resolved_state(finding=finding),
     )
     reporter = MagicMock()
@@ -479,34 +468,31 @@ def test_verdict_explainer_renders_on_every_round(
     findings: tuple[ReviewFinding, ...],
     verdict: ReviewVerdict,
 ) -> None:
-    """A clean run needs the rubric most: it proves the verdict was derived."""
-    del verdict  # Named for readability of the parametrization only.
+    """The title carries the derived verdict on every round."""
     body = _body_only(
         body=build_sticky_comment(
             result=_with(base=sample_review_result, findings=findings),
         ),
     )
+    labels = {
+        ReviewVerdict.READY: "✅ Ready",
+        ReviewVerdict.BLOCKED: "⛔ Blocked",
+    }
 
-    assert_that(body).contains(f"<sub>{VERDICT_RUBRIC_FINE_PRINT}</sub>")
+    assert_that(body).contains(f"## 🔎 Lintro Review — {labels[verdict]}")
 
 
 def test_verdict_explainer_sits_directly_under_the_pill(
     sample_review_result: ReviewResult,
 ) -> None:
-    """It explains the pill, so it renders before anything else does."""
+    """The mockup puts the derived verdict in the title, not a separate pill."""
     body = _body_only(
         body=build_sticky_comment(
             result=_with(base=sample_review_result, findings=(_finding(),)),
         ),
     )
-    sections = [section for section in body.split("\n\n") if section.strip()]
-    pill_at = next(
-        index for index, section in enumerate(sections) if "Blocked**" in section
-    )
 
-    assert_that(sections[pill_at + 1]).is_equal_to(
-        f"<sub>{VERDICT_RUBRIC_FINE_PRINT}</sub>",
-    )
+    assert_that(body).contains("## 🔎 Lintro Review — ⛔ Blocked")
 
 
 def test_verdict_rubric_reads_in_the_mock_style() -> None:

--- a/tests/unit/ai/review/test_orchestrator.py
+++ b/tests/unit/ai/review/test_orchestrator.py
@@ -36,12 +36,16 @@ from lintro.ai.review.orchestrator import (
 from lintro.ai.review.progress import ReviewProgressCallback
 
 
-def _sample_response_json(*, include_finding: bool = True) -> str:
+def _sample_response_json(
+    *,
+    include_finding: bool = True,
+    finding_file: str = "src/main.py",
+) -> str:
     finding = (
         {
             "severity": "P1",
             "category": "security",
-            "file": "src/main.py",
+            "file": finding_file,
             "line": 12,
             "title": "Fail-open default",
             "description": "Unknown status grants access",
@@ -117,6 +121,20 @@ def _one_file_context() -> ReviewContext:
     )
 
 
+def _two_file_context() -> ReviewContext:
+    """Build a two-file context matching the mid-run chunk fixtures."""
+    return ReviewContext(
+        base_ref="main",
+        head_ref="feature",
+        changed_files=[
+            ChangedFile(path="a.py", status="modified", additions=1, deletions=0),
+            ChangedFile(path="b.py", status="modified", additions=1, deletions=0),
+        ],
+        unified_diff=("diff --git a/a.py b/a.py\n+x\ndiff --git a/b.py b/b.py\n+y"),
+        pr_metadata=None,
+    )
+
+
 def test_run_review_marks_cli_transport_tokens_estimated() -> None:
     """CLI transport flags token usage as locally estimated in metadata."""
     provider = _mock_provider(content=_sample_response_json())
@@ -150,7 +168,7 @@ def test_run_review_marks_cli_transport_tokens_estimated() -> None:
 
 def test_run_review_returns_partial_on_cost_cap() -> None:
     """Cost cap mid-run finalizes a partial review instead of erroring."""
-    provider = _mock_provider(content=_sample_response_json())
+    provider = _mock_provider(content=_sample_response_json(finding_file="a.py"))
     chunks = [
         ReviewChunk(
             id=1,
@@ -193,7 +211,7 @@ def test_run_review_returns_partial_on_cost_cap() -> None:
         ),
     ):
         result = run_review(
-            _one_file_context(),
+            _two_file_context(),
             provider=provider,
             ai_config=AIConfig(
                 enabled=True,
@@ -312,7 +330,7 @@ def test_run_review_raises_on_genuine_provider_error_mid_review() -> None:
         pytest.raises(AIError),
     ):
         run_review(
-            _one_file_context(),
+            _two_file_context(),
             provider=provider,
             ai_config=AIConfig(enabled=True, transport=AITransport.API),
             depth=1,
@@ -762,8 +780,8 @@ def _multi_chunks(*, count: int = 4) -> list[ReviewChunk]:
     ]
 
 
-def test_run_review_parallelizes_with_cost_cap(tmp_path: Path) -> None:
-    """A cost cap must not force serial chunk reviews (issue #1969)."""
+def test_run_review_serializes_when_cost_cap_is_set(tmp_path: Path) -> None:
+    """A cost cap forces serial chunk reviews so queue order cannot invert."""
     context = _multi_chunk_context(tmp_path=tmp_path, count=4)
     chunks = _multi_chunks(count=4)
     provider = _mock_provider(content=_sample_response_json(include_finding=False))
@@ -822,7 +840,7 @@ def test_run_review_parallelizes_with_cost_cap(tmp_path: Path) -> None:
             classifications=[],
         )
 
-    assert_that(max_active).is_greater_than(1)
+    assert_that(max_active).is_equal_to(1)
     assert_that(result.metadata.partial).is_false()
     assert_that(result.metadata.chunks_reviewed).is_equal_to(4)
 
@@ -875,7 +893,6 @@ def test_run_review_parallelizes_depth_two_chunks(tmp_path: Path) -> None:
                 enabled=True,
                 transport=AITransport.API,
                 max_parallel_calls=4,
-                max_cost_usd=5.0,
             ),
             depth=2,
             checklist_items=[],

--- a/tests/unit/ai/review/test_resume_fake_transport.py
+++ b/tests/unit/ai/review/test_resume_fake_transport.py
@@ -6,17 +6,25 @@ from unittest.mock import MagicMock, patch
 
 from assertpy import assert_that
 
+from lintro.ai.budget import CostBudget
 from lintro.ai.config import AIConfig
 from lintro.ai.enums import AITransport
 from lintro.ai.providers.capabilities import ProviderCapabilities
 from lintro.ai.providers.response import AIResponse
+from lintro.ai.review.enums.file_review_need import FileReviewNeed
 from lintro.ai.review.enums.review_verdict import ReviewVerdict
+from lintro.ai.review.group_labels import REL_SINGLE_FILE
 from lintro.ai.review.models.changed_file import ChangedFile
+from lintro.ai.review.models.coverage_counts import CoverageCounts
 from lintro.ai.review.models.coverage_record import CoverageRecord
+from lintro.ai.review.models.flagged_file import FlaggedFile
+from lintro.ai.review.models.review_chunk import ReviewChunk
 from lintro.ai.review.models.review_context import ReviewContext
+from lintro.ai.review.models.review_result import ReviewResult
 from lintro.ai.review.models.review_state import ReviewState
 from lintro.ai.review.orchestrator import run_review
 from lintro.ai.review.patch_hash import normalized_patch_hash
+from lintro.ai.review.resume import plan_resume
 
 
 def _diff(*, path: str, added: str) -> str:
@@ -77,7 +85,7 @@ def _run(
     force_full: bool = False,
     calls: list[int] | None = None,
     payload_file: str = "a.py",
-) -> object:
+) -> ReviewResult:
     """Run a review with a recording fake transport."""
     provider = _provider()
 
@@ -108,23 +116,31 @@ def _run(
         )
 
 
+def _require_coverage(result: ReviewResult) -> CoverageCounts:
+    """Return coverage counters, failing the test when they are missing."""
+    coverage = result.coverage
+    assert coverage is not None
+    return coverage
+
+
 def test_quiet_rereview_makes_zero_provider_calls() -> None:
     """An unchanged covered HEAD spends no budget, including custom agents."""
     context = _context("a.py")
     first_calls: list[int] = []
     first = _run(context=context, calls=first_calls, payload_file="a.py")
     assert_that(first_calls).is_length(1)
-    assert_that(first.coverage).is_not_none()
-    assert_that(first.coverage.complete).is_true()
+    first_coverage = _require_coverage(first)
+    assert_that(first_coverage.complete).is_true()
     assert_that(first.coverage_records).is_not_empty()
 
     prior = ReviewState(coverage=first.coverage_records)
     second_calls: list[int] = []
     second = _run(context=context, prior=prior, calls=second_calls)
+    second_coverage = _require_coverage(second)
     assert_that(second_calls).is_empty()
-    assert_that(second.coverage.complete).is_true()
-    assert_that(second.coverage.reviewed).is_equal_to(0)
-    assert_that(second.coverage.carried).is_greater_than(0)
+    assert_that(second_coverage.complete).is_true()
+    assert_that(second_coverage.reviewed).is_equal_to(0)
+    assert_that(second_coverage.carried).is_greater_than(0)
     assert_that(second.findings).is_empty()
 
 
@@ -164,7 +180,7 @@ def test_content_identical_rebase_keeps_coverage() -> None:
     calls: list[int] = []
     result = _run(context=context, prior=prior, calls=calls)
     assert_that(calls).is_empty()
-    assert_that(result.coverage.complete).is_true()
+    assert_that(_require_coverage(result).complete).is_true()
 
 
 def test_partial_round_is_incomplete() -> None:
@@ -180,6 +196,163 @@ def test_partial_round_is_incomplete() -> None:
     )
     prior = ReviewState(coverage=covered)
     result = _run(context=context, prior=prior, payload_file="b.py")
-    assert_that(result.coverage).is_not_none()
-    if not result.coverage.complete:
+    if not _require_coverage(result).complete:
         assert_that(result.readiness_verdict).is_equal_to(ReviewVerdict.INCOMPLETE)
+
+
+def _shared_line_diff(*, path: str) -> str:
+    """Return a unified diff whose +/- lines match any sibling using this helper."""
+    return (
+        f"diff --git a/{path} b/{path}\n"
+        f"--- a/{path}\n"
+        f"+++ b/{path}\n"
+        "@@ -1,1 +1,2 @@\n"
+        " context\n"
+        "+shared-change\n"
+    )
+
+
+def _single_file_chunks(*, diffs: dict[str, str]) -> list[ReviewChunk]:
+    """Return one isolated chunk per path so a cap can stop mid-queue."""
+    return [
+        ReviewChunk(
+            id=index,
+            files=[path],
+            diff=text,
+            relationship=REL_SINGLE_FILE,
+        )
+        for index, (path, text) in enumerate(diffs.items(), start=1)
+    ]
+
+
+def _run_capped(
+    *,
+    context: ReviewContext,
+    chunks: list[ReviewChunk],
+    prior: ReviewState | None = None,
+    payload_file: str = "a.py",
+    calls: list[int] | None = None,
+) -> ReviewResult:
+    """Run a serial $0.01-capped review against isolated chunks."""
+    provider = _provider()
+
+    def _call_ai(**kwargs: object) -> AIResponse:
+        if calls is not None:
+            calls.append(1)
+        budget = kwargs.get("budget")
+        response = AIResponse(
+            content=_payload(file=payload_file),
+            model="fake-model",
+            input_tokens=10,
+            output_tokens=5,
+            cost_estimate=0.01,
+            provider="fake",
+        )
+        if isinstance(budget, CostBudget):
+            budget.record(response.cost_estimate)
+        return response
+
+    with (
+        patch(
+            "lintro.ai.review.orchestrator.resolve_review_chunks",
+            return_value=chunks,
+        ),
+        patch("lintro.ai.review.orchestrator.call_ai", side_effect=_call_ai),
+    ):
+        return run_review(
+            context,
+            provider=provider,
+            ai_config=AIConfig(
+                enabled=True,
+                transport=AITransport.API,
+                max_cost_usd=0.01,
+                max_parallel_calls=1,
+            ),
+            depth=1,
+            checklist_items=[],
+            checklist_text="1. [logic-bug] Example?",
+            classifications=[],
+            prior_state=prior,
+            force_full=False,
+            enforce_cost_cap=True,
+        )
+
+
+def test_inherited_sibling_clears_pending_after_capped_round() -> None:
+    """Sampler-omitted same-hash mates must not stay pending forever."""
+    keep = "keep.py"
+    skip = "skip.py"
+    shared_hash = normalized_patch_hash(_shared_line_diff(path=keep))
+    context = ReviewContext(
+        base_ref="main",
+        head_ref="feature",
+        changed_files=[
+            ChangedFile(path=keep, status="modified", additions=1, deletions=0),
+            ChangedFile(path=skip, status="modified", additions=1, deletions=0),
+        ],
+        unified_diff="\n".join(
+            (_shared_line_diff(path=keep), _shared_line_diff(path=skip)),
+        ),
+        pr_metadata=None,
+    )
+    prior = ReviewState(
+        coverage=(
+            CoverageRecord(keep, shared_hash, round=1),
+            CoverageRecord(skip, shared_hash, round=1),
+        ),
+        pending_invalidations=(
+            (keep, FileReviewNeed.GROUP_INVALIDATED.value),
+            (skip, FileReviewNeed.GROUP_INVALIDATED.value),
+        ),
+    )
+    calls: list[int] = []
+    result = _run_capped(
+        context=context,
+        chunks=_single_file_chunks(
+            diffs={
+                keep: _shared_line_diff(path=keep),
+                skip: _shared_line_diff(path=skip),
+            },
+        ),
+        prior=prior,
+        payload_file=keep,
+        calls=calls,
+    )
+    assert_that(calls).is_length(1)
+    pending_paths = {path for path, _need in result.pending_invalidations}
+    covered_paths = {record.path for record in result.coverage_records}
+    assert_that(covered_paths).contains(skip)
+    assert_that(pending_paths).does_not_contain(skip)
+
+
+def test_unserved_model_flag_stays_queued_after_capped_round() -> None:
+    """An unserved MODEL_FLAGGED path must still classify as flagged next round."""
+    extras = "extras.py"
+    extras_diff = _diff(path=extras, added=f"change-{extras}")
+    extras_hash = normalized_patch_hash(extras_diff)
+    a_diff = _diff(path="a.py", added="change-a.py")
+    context = _context("a.py", extras)
+    prior = ReviewState(
+        coverage=(CoverageRecord(extras, extras_hash, round=1),),
+        flagged_files=(FlaggedFile(extras, "re-check contract", extras_hash),),
+    )
+    calls: list[int] = []
+    first = _run_capped(
+        context=context,
+        chunks=_single_file_chunks(diffs={"a.py": a_diff, extras: extras_diff}),
+        prior=prior,
+        payload_file="a.py",
+        calls=calls,
+    )
+    assert_that(calls).is_length(1)
+    assert_that([flag.path for flag in first.flagged_files]).contains(extras)
+    nxt = plan_resume(
+        context=context,
+        prior=ReviewState(
+            coverage=first.coverage_records,
+            flagged_files=first.flagged_files,
+        ),
+    )
+    by_path = {item.path: item.need for item in nxt.classified}
+    assert_that(by_path[extras]).is_equal_to(FileReviewNeed.MODEL_FLAGGED)
+    assert_that(nxt.queue).contains(extras)

--- a/tests/unit/ai/review/test_resume_fake_transport.py
+++ b/tests/unit/ai/review/test_resume_fake_transport.py
@@ -1,0 +1,185 @@
+"""Fake-transport acceptance for file-level resume (#2154)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from assertpy import assert_that
+
+from lintro.ai.config import AIConfig
+from lintro.ai.enums import AITransport
+from lintro.ai.providers.capabilities import ProviderCapabilities
+from lintro.ai.providers.response import AIResponse
+from lintro.ai.review.enums.review_verdict import ReviewVerdict
+from lintro.ai.review.models.changed_file import ChangedFile
+from lintro.ai.review.models.coverage_record import CoverageRecord
+from lintro.ai.review.models.review_context import ReviewContext
+from lintro.ai.review.models.review_state import ReviewState
+from lintro.ai.review.orchestrator import run_review
+from lintro.ai.review.patch_hash import normalized_patch_hash
+
+
+def _diff(*, path: str, added: str) -> str:
+    """Return a tiny unified diff for one file."""
+    return (
+        f"diff --git a/{path} b/{path}\n"
+        f"--- a/{path}\n"
+        f"+++ b/{path}\n"
+        "@@ -1,1 +1,2 @@\n"
+        " context\n"
+        f"+{added}\n"
+    )
+
+
+def _context(*paths: str) -> ReviewContext:
+    """Build a review context with one added line per path."""
+    files = [
+        ChangedFile(path=path, status="modified", additions=1, deletions=0)
+        for path in paths
+    ]
+    unified = "\n".join(_diff(path=path, added=f"change-{path}") for path in paths)
+    return ReviewContext(
+        base_ref="main",
+        head_ref="feature",
+        changed_files=files,
+        unified_diff=unified,
+        pr_metadata=None,
+    )
+
+
+def _payload(*, file: str) -> str:
+    """Return a valid review JSON payload with one finding on ``file``."""
+    return (
+        "{"
+        '"summary": "ok",'
+        '"checklist": [],'
+        f'"findings": [{{'
+        f'"severity": "P3", "category": "logic-bug", "file": "{file}",'
+        '"line": 1, "title": "Nit", "description": "d", "cause": "c",'
+        '"fix": "f", "confidence": "high"'
+        "}]}"
+    )
+
+
+def _provider() -> MagicMock:
+    """Return a session-less provider whose complete() is unused."""
+    provider = MagicMock()
+    provider.model_name = "fake-model"
+    provider.name = "fake"
+    provider.capabilities = ProviderCapabilities(supports_sessions=False)
+    return provider
+
+
+def _run(
+    *,
+    context: ReviewContext,
+    prior: ReviewState | None = None,
+    force_full: bool = False,
+    calls: list[int] | None = None,
+    payload_file: str = "a.py",
+) -> object:
+    """Run a review with a recording fake transport."""
+    provider = _provider()
+
+    def _call_ai(**_kwargs: object) -> AIResponse:
+        if calls is not None:
+            calls.append(1)
+        return AIResponse(
+            content=_payload(file=payload_file),
+            model="fake-model",
+            input_tokens=10,
+            output_tokens=5,
+            cost_estimate=0.01,
+            provider="fake",
+        )
+
+    with patch("lintro.ai.review.orchestrator.call_ai", side_effect=_call_ai):
+        return run_review(
+            context,
+            provider=provider,
+            ai_config=AIConfig(enabled=True, transport=AITransport.API),
+            depth=1,
+            checklist_items=[],
+            checklist_text="1. [logic-bug] Example?",
+            classifications=[],
+            prior_state=prior,
+            force_full=force_full,
+            enforce_cost_cap=False,
+        )
+
+
+def test_quiet_rereview_makes_zero_provider_calls() -> None:
+    """An unchanged covered HEAD spends no budget, including custom agents."""
+    context = _context("a.py")
+    first_calls: list[int] = []
+    first = _run(context=context, calls=first_calls, payload_file="a.py")
+    assert_that(first_calls).is_length(1)
+    assert_that(first.coverage).is_not_none()
+    assert_that(first.coverage.complete).is_true()
+    assert_that(first.coverage_records).is_not_empty()
+
+    prior = ReviewState(coverage=first.coverage_records)
+    second_calls: list[int] = []
+    second = _run(context=context, prior=prior, calls=second_calls)
+    assert_that(second_calls).is_empty()
+    assert_that(second.coverage.complete).is_true()
+    assert_that(second.coverage.reviewed).is_equal_to(0)
+    assert_that(second.coverage.carried).is_greater_than(0)
+    assert_that(second.findings).is_empty()
+
+
+def test_full_flag_discards_carried_coverage() -> None:
+    """``--full`` re-reviews files that would otherwise be carried."""
+    context = _context("a.py")
+    first = _run(context=context, payload_file="a.py")
+    prior = ReviewState(coverage=first.coverage_records)
+    calls: list[int] = []
+    _run(context=context, prior=prior, force_full=True, calls=calls)
+    assert_that(calls).is_not_empty()
+
+
+def test_content_identical_rebase_keeps_coverage() -> None:
+    """Hunk-header drift does not invalidate a stored hash."""
+    path = "a.py"
+    left = "@@ -1,3 +1,3 @@\n context\n-old\n+new\n"
+    right = "@@ -10,5 +10,5 @@\n other\n-old\n+new\n"
+    assert_that(normalized_patch_hash(left)).is_equal_to(normalized_patch_hash(right))
+    prior = ReviewState(
+        coverage=(
+            CoverageRecord(
+                path=path,
+                patch_hash=normalized_patch_hash(left),
+            ),
+        ),
+    )
+    context = ReviewContext(
+        base_ref="main",
+        head_ref="rebased",
+        changed_files=[
+            ChangedFile(path=path, status="modified", additions=1, deletions=1),
+        ],
+        unified_diff=f"diff --git a/{path} b/{path}\n{right}",
+        pr_metadata=None,
+    )
+    calls: list[int] = []
+    result = _run(context=context, prior=prior, calls=calls)
+    assert_that(calls).is_empty()
+    assert_that(result.coverage.complete).is_true()
+
+
+def test_partial_round_is_incomplete() -> None:
+    """Coverage-at-HEAD below 100% forces INCOMPLETE even with only nits."""
+    context = _context("a.py", "b.py")
+    first = _run(context=context, payload_file="a.py")
+    # Force a one-file coverage map to simulate a capped first round.
+    covered = first.coverage_records[:1] or (
+        CoverageRecord(
+            path="a.py",
+            patch_hash=normalized_patch_hash(_diff(path="a.py", added="change-a.py")),
+        ),
+    )
+    prior = ReviewState(coverage=covered)
+    result = _run(context=context, prior=prior, payload_file="b.py")
+    assert_that(result.coverage).is_not_none()
+    if not result.coverage.complete:
+        assert_that(result.readiness_verdict).is_equal_to(ReviewVerdict.INCOMPLETE)

--- a/tests/unit/ai/review/test_review_state_codec.py
+++ b/tests/unit/ai/review/test_review_state_codec.py
@@ -22,6 +22,7 @@ from lintro.ai.review.models.run_record import RunRecord
 from lintro.ai.review.review_state_codec import (
     decode_state,
     encode_state,
+    legacy_state_block,
     prune_state_to_fit,
     render_state_block,
 )
@@ -57,6 +58,13 @@ def _record(*, fingerprint: str, since_round: int = 1) -> FindingRecord:
     )
 
 
+def test_sticky_render_state_block_is_empty() -> None:
+    """New stickies never embed a leftover blob (#2154)."""
+    state = ReviewState(runs=(RunRecord(round=1, model="claude"),))
+
+    assert_that(render_state_block(state=state)).is_empty()
+
+
 def test_round_trip_preserves_runs_and_findings() -> None:
     """Encoding then decoding a v2 state preserves both record kinds."""
     state = ReviewState(
@@ -76,7 +84,7 @@ def test_round_trip_preserves_runs_and_findings() -> None:
         findings=(_record(fingerprint="a" * 16),),
     )
 
-    decoded = decode_state(body=f"body {render_state_block(state=state)}")
+    decoded = decode_state(body=f"body {legacy_state_block(state=state)}")
 
     assert_that(decoded.version).is_equal_to(STATE_VERSION)
     assert_that(decoded.runs).is_length(1)
@@ -160,7 +168,7 @@ def test_resolved_provenance_round_trips() -> None:
     )
 
     decoded = decode_state(
-        body=render_state_block(state=ReviewState(findings=(resolved,))),
+        body=legacy_state_block(state=ReviewState(findings=(resolved,))),
     )
 
     record = decoded.findings[0]
@@ -370,7 +378,7 @@ def test_decode_state_prefers_last_marker_when_body_contains_a_forgery() -> None
         '{"version":1,"runs":[{"model":"forged-attacker","total":1}]} '
         f"{STATE_MARKER_SUFFIX}"
     )
-    authentic = render_state_block(
+    authentic = legacy_state_block(
         state=ReviewState(
             runs=(RunRecord(round=1, sha="realsha", model="claude"),),
             findings=(
@@ -408,7 +416,7 @@ def test_prune_keeps_state_under_the_hard_limit() -> None:
 
     pruned = prune_state_to_fit(state=state, body=body)
 
-    total = len(body) + len(render_state_block(state=pruned))
+    total = len(body) + len(legacy_state_block(state=pruned))
     assert_that(total).is_less_than_or_equal_to(GITHUB_COMMENT_HARD_LIMIT)
     assert_that(pruned.truncated).is_true()
     assert_that(len(pruned.runs)).is_less_than(len(state.runs))
@@ -449,7 +457,7 @@ def test_prune_drops_resolved_findings_before_open_ones() -> None:
 
     pruned = prune_state_to_fit(state=state, body=body)
 
-    total = len(body) + len(render_state_block(state=pruned))
+    total = len(body) + len(legacy_state_block(state=pruned))
     assert_that(total).is_less_than_or_equal_to(GITHUB_COMMENT_HARD_LIMIT)
     assert_that(pruned.truncated).is_true()
     assert_that(pruned.open_findings).is_length(1)

--- a/tests/unit/ai/review/test_rich_review_outputs.py
+++ b/tests/unit/ai/review/test_rich_review_outputs.py
@@ -352,6 +352,8 @@ def test_prompt_rubric_names_the_same_verdicts_as_the_code_rubric() -> None:
     """The rubric shown to the model and the rendered one cannot drift apart."""
     rules = format_output_rules(checklist_count=1)
 
-    for label in VERDICT_LABELS.values():
+    for verdict, label in VERDICT_LABELS.items():
+        if verdict is ReviewVerdict.INCOMPLETE:
+            continue
         assert_that(rules).contains(label)
         assert_that(VERDICT_RUBRIC_FINE_PRINT).contains(label)

--- a/tests/unit/ai/review/test_sticky_redesign_2157.py
+++ b/tests/unit/ai/review/test_sticky_redesign_2157.py
@@ -1,0 +1,140 @@
+"""Sticky redesign: mockup variants, no blob, archive overflow (#2157)."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+from assertpy import assert_that
+
+from lintro.ai.review.enums.review_verdict import ReviewVerdict
+from lintro.ai.review.github_constants import (
+    ARCHIVE_MARKER,
+    STATE_MARKER_PREFIX,
+    STICKY_FOOTER,
+)
+from lintro.ai.review.github_sticky import (
+    build_sticky_bodies,
+    build_sticky_comment,
+    render_state_sticky,
+)
+from lintro.ai.review.models.coverage_counts import CoverageCounts
+from lintro.ai.review.models.review_finding import ReviewFinding, Severity
+from lintro.ai.review.models.review_result import ReviewResult
+from lintro.ai.review.models.review_state import ReviewState
+from lintro.ai.review.models.run_record import RunRecord
+
+
+def _finding() -> ReviewFinding:
+    """Return one nit for sticky layout tests."""
+    return ReviewFinding(
+        severity=Severity.P3,
+        category="logic-bug",
+        file="src/app.py",
+        line=10,
+        title="Nit title",
+        description="d",
+        cause="c",
+        fix="f",
+        confidence="high",
+    )
+
+
+def test_complete_round_matches_variant_a(sample_review_result: ReviewResult) -> None:
+    """Variant A: verdict in the title, findings heading, single This-run row."""
+    result = replace(
+        sample_review_result,
+        findings=(_finding(),),
+        coverage=CoverageCounts(reviewed=3, carried=0, awaiting=0, eligible=3),
+    )
+    body = build_sticky_comment(result=result, head_sha="abc1234")
+
+    assert_that(body).contains("## 🔎 Lintro Review — 🟡 Nits only")
+    assert_that(body).contains("### Findings · Round 1 · `abc1234`")
+    assert_that(body).contains("✅ 3/3 at HEAD")
+    assert_that(body).contains("| Δ | Sev | Finding | Where | Since |")
+    assert_that(body).contains("**new**")
+    assert_that(body).contains("**This run**")
+    assert_that(body).contains("| model | transport | est. cost | tokens in / out |")
+    assert_that(body).does_not_contain(STATE_MARKER_PREFIX)
+    assert_that(body).contains("how to read this report")
+    assert_that(body).contains(STICKY_FOOTER)
+
+
+def test_incomplete_round_matches_variant_b(sample_review_result: ReviewResult) -> None:
+    """Variant B: Incomplete title, warning, coverage table, flag reasons."""
+    result = replace(
+        sample_review_result,
+        findings=(_finding(),),
+        coverage=CoverageCounts(
+            reviewed=14,
+            carried=0,
+            awaiting=23,
+            invalidated=1,
+            eligible=37,
+        ),
+        awaiting_paths=("lintro/ai/review/orchestrator.py", "src/other.py"),
+        awaiting_reasons=(("src/other.py", "import contract changed"),),
+    )
+    body = build_sticky_comment(result=result, head_sha="a1b2c3d")
+
+    assert_that(body).contains("## 🔎 Lintro Review — ⚠️ Incomplete")
+    assert_that(body).contains("> [!WARNING]")
+    assert_that(body).contains("Verdict withheld")
+    assert_that(body).contains("### Coverage this round")
+    assert_that(body).contains("import contract changed")
+    assert_that(body).contains("⚠️ 14/37 files")
+    assert_that(result.readiness_verdict).is_equal_to(ReviewVerdict.INCOMPLETE)
+
+
+def test_sticky_writes_no_state_blob(sample_review_result: ReviewResult) -> None:
+    """Authoritative state is not embedded in the comment."""
+    body = build_sticky_comment(result=sample_review_result)
+    assert_that(body).does_not_contain(STATE_MARKER_PREFIX)
+
+
+def test_render_state_sticky_empty_state_is_defined() -> None:
+    """A failed round with no artifact still renders a first-failure surface."""
+    body = render_state_sticky(state=ReviewState(), banner="> provider outage")
+
+    assert_that(body).contains("## 🔎 Lintro Review — no prior review")
+    assert_that(body).contains("provider outage")
+    assert_that(body).does_not_contain(STATE_MARKER_PREFIX)
+
+
+def test_archive_comment_is_created_when_history_overflows(
+    sample_review_result: ReviewResult,
+) -> None:
+    """History expanders move to the archive past the soft limit."""
+    runs = tuple(
+        RunRecord(
+            round=index,
+            sha=f"{index:07x}",
+            model="m",
+            narrative="x" * 400,
+            cost=1.0,
+            total=10_000,
+            prompt=8000,
+            completion=2000,
+            duration=100,
+            files_reviewed=20,
+            checks=10,
+            verdict=ReviewVerdict.CHANGES_REQUESTED,
+            resolved=2,
+            open_after=3,
+        )
+        for index in range(1, 40)
+    )
+    prior = ReviewState(runs=runs)
+    _primary, archive = build_sticky_bodies(
+        result=sample_review_result,
+        prior_state=prior,
+        head_sha="fffffff",
+    )
+    # Soft-limit split is size-driven; a large run history must produce
+    # either an archive or a primary that still names History.
+    if archive is not None:
+        assert_that(archive).contains(ARCHIVE_MARKER)
+        assert_that(archive).contains("history archive")
+        assert_that(_primary).contains("### 🕘 History")
+    else:
+        assert_that(_primary).contains("### 🕘 History")

--- a/tests/unit/ai/review/test_verdict.py
+++ b/tests/unit/ai/review/test_verdict.py
@@ -112,8 +112,14 @@ def test_verdict_labels_cover_every_member() -> None:
 
 
 def test_verdict_rubric_fine_print_names_every_label() -> None:
-    """The rendered rubric fine-print states each verdict label."""
-    for label in VERDICT_LABELS.values():
+    """The rendered rubric fine-print states each findings-derived label.
+
+    ``Incomplete`` is a coverage gate, not a severity outcome, so it is
+    announced on the sticky rather than in this findings rubric.
+    """
+    for verdict, label in VERDICT_LABELS.items():
+        if verdict is ReviewVerdict.INCOMPLETE:
+            continue
         assert_that(VERDICT_RUBRIC_FINE_PRINT).contains(label)
 
 

--- a/tests/unit/ai/test_config_overrides.py
+++ b/tests/unit/ai/test_config_overrides.py
@@ -317,20 +317,38 @@ def test_max_cost_usd_flag_beats_env(monkeypatch: pytest.MonkeyPatch) -> None:
     assert_that(resolved.source_of("max_cost_usd")).is_equal_to(ConfigSource.FLAG)
 
 
-def test_max_cost_usd_zero_is_uncapped(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Literal ``0`` lifts the ceiling to ``None``, matching CostBudget (#2024)."""
-    monkeypatch.setenv("LINTRO_AI_MAX_COST_USD", "0")
+def test_max_cost_usd_uncapped_sentinel(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``uncapped`` lifts the ceiling to ``None`` (#2154)."""
+    monkeypatch.setenv("LINTRO_AI_MAX_COST_USD", "UNCAPPED")
 
     from_env = AIConfig.resolve_from_mapping(_mapping(max_cost_usd=0.5))
     from_flag = apply_cli_overrides(
         AIConfig.resolve_from_mapping(_mapping(max_cost_usd=0.5)),
-        max_cost_usd=0.0,
+        max_cost_usd="uncapped",
     )
 
     assert_that(from_env.config.max_cost_usd).is_none()
     assert_that(from_env.source_of("max_cost_usd")).is_equal_to(ConfigSource.ENV)
     assert_that(from_flag.config.max_cost_usd).is_none()
     assert_that(from_flag.source_of("max_cost_usd")).is_equal_to(ConfigSource.FLAG)
+
+
+def test_max_cost_usd_overlay_zero_is_rejected(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Overlay ``0`` is ambiguous and errors (#2154)."""
+    monkeypatch.setenv("LINTRO_AI_MAX_COST_USD", "0")
+
+    with pytest.raises(AIConfigOverrideError) as env_info:
+        AIConfig.resolve_from_mapping(_mapping(max_cost_usd=0.5))
+    assert_that(str(env_info.value)).contains("ambiguous")
+
+    with pytest.raises(AIConfigOverrideError) as flag_info:
+        apply_cli_overrides(
+            AIConfig.resolve_from_mapping(_mapping(max_cost_usd=0.5)),
+            max_cost_usd=0.0,
+        )
+    assert_that(str(flag_info.value)).contains("uncapped")
 
 
 def test_yaml_zero_is_a_zero_dollar_cap_not_uncapped() -> None:
@@ -350,7 +368,7 @@ def test_max_cost_usd_overlay_beats_transport_profile(
         "transport": "cli",
         "transports": {"cli": {"max_cost_usd_advisory": 1.25}},
     }
-    monkeypatch.setenv("LINTRO_AI_MAX_COST_USD", "0")
+    monkeypatch.setenv("LINTRO_AI_MAX_COST_USD", "uncapped")
 
     from_env = AIConfig.resolve_from_mapping(mapping)
     applied_env = apply_resolved_transport(from_env.config)
@@ -367,7 +385,7 @@ def test_max_cost_usd_overlay_beats_transport_profile(
                 "transports": {"cli": {"max_cost_usd_advisory": 1.25}},
             },
         ),
-        max_cost_usd=0,
+        max_cost_usd="uncapped",
     )
     applied_flag = apply_resolved_transport(from_flag.config)
 
@@ -416,7 +434,7 @@ def test_flag_overlay_provenance_beats_profile_cap() -> None:
                 "transports": {"api": {"max_cost_usd": 1.25}},
             },
         ),
-        max_cost_usd=0,
+        max_cost_usd="uncapped",
     )
     cap, source = resolve_max_cost_with_source(resolved)
 
@@ -433,7 +451,7 @@ def test_invalid_max_cost_usd_env_fails_loud(monkeypatch: pytest.MonkeyPatch) ->
 
     message = str(exc_info.value)
     assert_that(message).contains("LINTRO_AI_MAX_COST_USD='plenty'")
-    assert_that(message).contains("0 for uncapped")
+    assert_that(message).contains("uncapped")
     assert_that(message).does_not_contain("Traceback")
 
 
@@ -447,7 +465,7 @@ def test_negative_max_cost_usd_fails_loud() -> None:
 
     message = str(exc_info.value)
     assert_that(message).contains("--max-cost-usd=-1.0")
-    assert_that(message).contains("0 for uncapped")
+    assert_that(message).contains("uncapped")
 
 
 def test_nonnumeric_max_cost_usd_flag_fails_loud() -> None:
@@ -460,7 +478,7 @@ def test_nonnumeric_max_cost_usd_flag_fails_loud() -> None:
 
     message = str(exc_info.value)
     assert_that(message).contains("--max-cost-usd='plenty'")
-    assert_that(message).contains("0 for uncapped")
+    assert_that(message).contains("uncapped")
 
 
 def test_nonfinite_max_cost_usd_fails_loud() -> None:
@@ -473,7 +491,7 @@ def test_nonfinite_max_cost_usd_fails_loud() -> None:
             )
         message = str(exc_info.value)
         assert_that(message).contains(f"--max-cost-usd='{raw}'")
-        assert_that(message).contains("0 for uncapped")
+        assert_that(message).contains("uncapped")
 
 
 def test_whitespace_max_cost_usd_env_is_unset(

--- a/tests/unit/cli/test_review_command.py
+++ b/tests/unit/cli/test_review_command.py
@@ -18,12 +18,16 @@ from lintro.ai.review.enums.checklist_display import ChecklistDisplay
 from lintro.ai.review.enums.custom_agent_mode import CustomAgentMode
 from lintro.ai.review.enums.review_strictness import ReviewStrictness
 from lintro.ai.review.exceptions import ReviewExecutionError
+from lintro.ai.review.models.coverage_record import CoverageRecord
 from lintro.ai.review.models.review_metadata import ReviewMetadata
 from lintro.ai.review.models.review_result import ReviewResult
+from lintro.ai.review.models.review_state import ReviewState
+from lintro.ai.review.state_store import write_local_state
 from lintro.cli import cli
 from lintro.cli_utils.commands.review import (
     _cli_overrides,
     _describe_config_source,
+    _load_prior_review_state,
     _merge_advisory_into_json,
 )
 from lintro.models.core.tool_result import ToolResult
@@ -1951,3 +1955,34 @@ def test_review_post_reports_config_source_and_transport() -> None:
         "`.lintro-config.yaml` + CLI overrides (--timeout 600)",
     )
     assert_that(kwargs["transport"]).is_equal_to(str(AITransport.API))
+
+
+def test_ci_does_not_import_the_local_ledger(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Actions runs may only resume from downloaded artifacts."""
+    ledger = tmp_path / "ledger"
+    write_local_state(
+        state=ReviewState(
+            coverage=(CoverageRecord("a.py", "h"),),
+            repo="lgtm-hq/py-lintro",
+            pr_number=999,
+        ),
+        key="pr-999",
+        directory=ledger,
+    )
+    monkeypatch.setattr(
+        "lintro.ai.review.state_store.LOCAL_STATE_DIR",
+        ledger,
+    )
+    monkeypatch.setenv("GITHUB_ACTIONS", "true")
+    monkeypatch.setenv("LINTRO_REVIEW_STATE_DIR", str(tmp_path / "empty-artifacts"))
+    (tmp_path / "empty-artifacts").mkdir()
+    loaded = _load_prior_review_state(
+        pr_number=999,
+        head_ref="feature",
+        repo="lgtm-hq/py-lintro",
+        post=False,
+    )
+    assert_that(loaded.coverage).is_empty()

--- a/tests/unit/cli/test_review_command.py
+++ b/tests/unit/cli/test_review_command.py
@@ -103,12 +103,12 @@ def test_review_nonnumeric_max_cost_usd_exits_two() -> None:
 
     assert_that(result.exit_code).is_equal_to(2)
     assert_that(result.output).contains("--max-cost-usd='plenty'")
-    assert_that(result.output).contains("0 for uncapped")
+    assert_that(result.output).contains("uncapped")
     assert_that(result.output).does_not_contain("Traceback")
 
 
 def test_review_max_cost_flag_beats_transport_profile() -> None:
-    """``--max-cost-usd 0`` lifts a YAML transport-profile cap (#2024)."""
+    """``--max-cost-usd uncapped`` lifts a YAML transport-profile cap (#2154)."""
     runner = CliRunner()
     mock_context = MagicMock()
     mock_context.changed_files = []
@@ -167,7 +167,7 @@ def test_review_max_cost_flag_beats_transport_profile() -> None:
             model_name="gpt-4o",
             name="openai",
         )
-        result = runner.invoke(cli, ["review", "--max-cost-usd", "0"])
+        result = runner.invoke(cli, ["review", "--max-cost-usd", "uncapped"])
 
     assert_that(result.exit_code).is_equal_to(0)
     provider_config = mock_get_provider.call_args.args[0]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  feat(ai)!: file-level review resume and sticky redesign
  ```

- Type:
  - [x] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [x] `!` in title or `BREAKING CHANGE:` footer included

## What’s Changing

File-level AI review resume (#2154) plus sticky redesign (#2157), the remaining
product work on epic #2156.

Coverage is keyed by `(path, normalized patch hash)` so content-identical
rebases keep coverage and chunk boundaries never constrain a later round.
Partial coverage can no longer render clean: `INCOMPLETE` reddens the
classifier check while `lintro review` exit codes stay 0/1/2. Authoritative
state moves to workflow artifacts and a local ledger; the sticky comment is
pure rendering (no hidden state blob). Overlay `0` is rejected (`uncapped`
is the sentinel); YAML `0` remains a literal $0 cap.

Review follow-ups on this PR:

- `25846512` — zero-call findings stay open, latest-hash direct-change,
  queue-ordered chunks, CI never reads the local ledger
- `08303f28` — persist explicit pending group/import invalidations so
  capped rounds converge (no round livelock); same-hash siblings count
  for coverage only, not matcher `reviewed_paths`
- `dbcb2731` — inherited same-hash coverage clears pending invalidations;
  unserved prior `flagged_files` persist across a capped round
- `451cef5b` — CLI persist copies the advanced `ReviewState` so pending
  pairs and consumed flags survive the artifact snapshot; same
  `(path, hash)` is flagged only once

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [x] Docs updated if user-facing
- [x] Local unit suite passed (`uv run pytest --maxfail=0 tests/unit/ai` — 2510 passed, 2 skipped)

## Related Issues

Closes #2154
Closes #2157
Related #2156

## Details

### Resume (#2154)

- Coverage identity: `+`/`-` lines only; `reviewed_sha` is metadata.
- Denominator: review-eligible files. Identical-hash sampled files inherit
  coverage, including same-round representatives. Inheritance is
  content-addressed (any identical hash), not restricted to the sampler
  skip reason.
- Invalidation: never-reviewed, directly changed, semantic-group, one-hop
  Python imports, and allowlisted `flagged_files` (capped, one-way,
  same file+hash once). Unserved group/import invalidation is persisted as
  `pending_invalidations` and cleared when the path is covered this round,
  including same-hash inheritance. Unserved prior model flags persist
  until that path is covered. Honored flags are recorded in
  `consumed_flags` so a repeat flag cannot re-queue the same unchanged
  file.
- Queue under a cap: never-reviewed → directly changed → model-flagged →
  group/import-invalidated. Chunks are filtered and ordered so serial
  capped runs cannot invert that order.
- Broadcast files (`pyproject.toml`, lockfiles, `conftest.py`) do not fan
  out via groups or the import graph.
- State: latest completed trusted run with a valid artifact (conclusion
  irrelevant). Local ledger at `.lintro-cache/ai/review-state/` (PR-number
  key, atomic write, LRU 32). CI never reads the local ledger. Sticky v2
  migration seeds findings+runs only (`legacy=True`), never coverage.
  Persist stamps identity onto `advance_review_state()` output instead of
  reconstructing a subset of fields.
- `--full` discards carried coverage. Never the default.

### Sticky (#2157)

- Mockup layout: title, findings table with Δ, single-row This-run, History
  with nested expanders, Variant B warning + flag reasons.
- Archive overflow at 56_000 chars. No hidden state blob.
- `docs/ai-review-report.md` is the reader-facing spec.

### Breaking change

Overlay `0` for `--max-cost-usd` / `LINTRO_AI_MAX_COST_USD` is rejected as
ambiguous. Use `uncapped`. YAML `0` remains a literal $0 cap.

### Known follow-ups (not merge blockers)

- Mid-run Actions artifact part uploads (`…-part-<seq>`) beyond the final
  `if: always()` upload. Parts are written locally; cancel-in-progress can
  still lose an in-flight window if `always()` skips.
- Persist currently happens before `--post`, so inline comment IDs are not
  in the first artifact snapshot.
- Repeat flags are dropped at classify time (convergence). Rendering them
  as an open question on the sticky is still a later polish item.

### Testing

- `UV_LINK_MODE=copy uv run pytest --maxfail=0 tests/unit/ai`: 2510 passed,
  2 skipped.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0ff3c26c-cf67-4c32-bff9-30643bc047b9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0ff3c26c-cf67-4c32-bff9-30643bc047b9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * AI reviews can resume at the file level, avoiding repeat analysis of unchanged files.
  * Added a `--full` option to force a complete re-review.
  * Review results now show coverage details and an **Incomplete** verdict when not all eligible files were reviewed.
  * Review state is preserved through CI artifacts and local review history.
  * Sticky comments now provide clearer findings, run history, coverage warnings, and archived details.

* **Bug Fixes**
  * Findings from unreviewed files remain open instead of being incorrectly resolved.
  * Clarified cost-cap behavior: use `uncapped` to remove limits; `0` is rejected for overlays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->