### PR TITLE
chore(ai): drop committed cost cap for uncapped dogfood

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -21,14 +21,13 @@ name: AI Review - Dogfood
 # authenticates only against an API key, which is precisely the credential that
 # does not work for the Anthropic dogfood (#1838).
 #
-# Spend ceiling defaults to the committed `ai.max_cost_usd: 2.00` in
-# `.lintro-config.yaml` (the empirically validated value from #1976/#1977; the
-# 0.50 that landed with #2018 / 9f43a98a was a side-effect, restored here by
-# #2025), overridable per-repo via the `LINTRO_AI_MAX_COST_USD` Actions
-# variable (#2024) so large multi-chunk PRs can complete instead of posting a
-# partial review every round. Under the CLI transport the call bills the
-# subscription, so the figure is advisory rather than enforced spend control
-# (#1923).
+# Spend ceiling: committed YAML leaves `ai.max_cost_usd` unset (#2156
+# rollout). The `LINTRO_AI_MAX_COST_USD` Actions variable is the operator
+# overlay (#2024 / #2155): `uncapped` lifts the ceiling; overlay `0` is
+# rejected as ambiguous. YAML `0` is still a literal $0 cap. Under the CLI
+# transport the figure is a runtime bound, not marginal dollars (#1923).
+# Historical note: #2018 / 9f43a98a briefly shipped 0.50; #2025 restored 2.00
+# as the interim committed cap; this rollout removes that committed cap.
 #
 # Posts a review comment: the review runs with `--post`, so lintro maintains a
 # single sticky comment on the PR (rich findings + cumulative telemetry) and
@@ -335,12 +334,12 @@ jobs:
           LINTRO_AI_TRANSPORT: ${{ vars.LINTRO_AI_TRANSPORT || 'cli' }}
           LINTRO_AI_PROVIDER: ${{ vars.LINTRO_AI_PROVIDER || 'anthropic' }}
           LINTRO_AI_MODEL: ${{ vars.LINTRO_AI_MODEL }}
-          # Spend ceiling override (#2024 / #2154). Unset falls through to
-          # the committed `ai.max_cost_usd: 2.00`. Overlay `uncapped` lifts
-          # the ceiling; overlay `0` is rejected as ambiguous. YAML `0` is
-          # still a literal $0 cap. The CLI transport treats a numeric cap
-          # as a runtime bound, not marginal dollars, under subscription
-          # auth.
+          # Spend ceiling overlay (#2024 / #2154 / #2156). Unset falls
+          # through to committed YAML (now unset = no cap). Overlay
+          # `uncapped` is the explicit lift; overlay `0` is rejected as
+          # ambiguous. YAML `0` is still a literal $0 cap. The CLI
+          # transport treats a numeric cap as a runtime bound, not
+          # marginal dollars, under subscription auth.
           LINTRO_AI_MAX_COST_USD: ${{ vars.LINTRO_AI_MAX_COST_USD }}
 
       - name: Upload review-state artifacts

--- a/.lintro-config.yaml
+++ b/.lintro-config.yaml
@@ -117,7 +117,8 @@ tools:
 ai:
   enabled: false
   review: true
-  max_cost_usd: 2.00
+  # No committed spend ceiling (#2156 rollout). CI overlays
+  # LINTRO_AI_MAX_COST_USD=uncapped; YAML `0` would be a literal $0 cap.
   provider: anthropic
   # model: claude-sonnet-4-20250514  # uses provider default if omitted
   # api_key_env: ANTHROPIC_API_KEY   # uses provider default if omitted

--- a/.lintro-config.yaml
+++ b/.lintro-config.yaml
@@ -117,8 +117,9 @@ tools:
 ai:
   enabled: false
   review: true
-  # No committed spend ceiling (#2156 rollout). CI overlays
-  # LINTRO_AI_MAX_COST_USD=uncapped; YAML `0` would be a literal $0 cap.
+  # No committed spend ceiling (#2156 rollout). CI forwards
+  # LINTRO_AI_MAX_COST_USD (dogfood operators set `uncapped`); YAML `0`
+  # would be a literal $0 cap.
   provider: anthropic
   # model: claude-sonnet-4-20250514  # uses provider default if omitted
   # api_key_env: ANTHROPIC_API_KEY   # uses provider default if omitted

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,8 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Changed
 
-- **ai-review**: remove the committed `ai.max_cost_usd: 2.00` dogfood cap so CI overlays
-  `LINTRO_AI_MAX_COST_USD=uncapped` (#2156)
+- **ai-review**: remove the committed `ai.max_cost_usd: 2.00` dogfood cap so CI can
+  overlay `LINTRO_AI_MAX_COST_USD=uncapped` (#2156)
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,8 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Changed
 
-- **ai-review**: remove the committed `ai.max_cost_usd: 2.00` dogfood cap so CI
-  overlays `LINTRO_AI_MAX_COST_USD=uncapped` (#2156)
+- **ai-review**: remove the committed `ai.max_cost_usd: 2.00` dogfood cap so CI overlays
+  `LINTRO_AI_MAX_COST_USD=uncapped` (#2156)
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Changed
 
+- **ai-review**: remove the committed `ai.max_cost_usd: 2.00` dogfood cap so CI
+  overlays `LINTRO_AI_MAX_COST_USD=uncapped` (#2156)
+
 ### Deprecated
 
 ### Removed

--- a/docs/adr/0006-ai-effective-config-and-review-execution.md
+++ b/docs/adr/0006-ai-effective-config-and-review-execution.md
@@ -78,10 +78,11 @@ Contract invariants:
 - Be consumed by execution, doctor/status, terminal review output, PR rendering, MCP,
   and advisory tools without reparsing the raw `ai:` mapping.
 - CLI and env overlays may raise or lift `ai.max_cost_usd` (`LINTRO_AI_MAX_COST_USD` /
-  `lintro review --max-cost-usd`; literal `0` = uncapped, mapped to `None`) (#2024).
-  Overlays beat transport profile caps as well as the legacy scalar; YAML `0` remains a
-  $0 cap. MCP's per-call `max_cost_usd` argument remains a monotonic clamp: it may lower
-  the effective ceiling, never raise it.
+  `lintro review --max-cost-usd`; overlay `uncapped` lifts the ceiling; overlay `0` is
+  rejected as ambiguous). Overlays beat transport profile caps as well as the legacy
+  scalar; YAML `0` remains a $0 cap. MCP's per-call `max_cost_usd` argument remains a
+  monotonic clamp: it may lower the effective ceiling, never raise it. #2024 originally
+  mapped overlay `0` to uncapped; #2154 / ADR-0007 superseded that.
 
 Issue #1970 implements the initial resolver (`AIConfig.resolve_from_mapping` returning
 `ResolvedAIConfig`). This epic must not introduce a second resolver. CLI review applies
@@ -183,8 +184,10 @@ time.
 - [#1970](https://github.com/lgtm-hq/py-lintro/issues/1970) — env/CLI override layer and
   provenance (owns `ResolvedAIConfig` implementation).
 - [#2024](https://github.com/lgtm-hq/py-lintro/issues/2024) — cost-cap overlay
-  (`LINTRO_AI_MAX_COST_USD` / `--max-cost-usd`; `0` = uncapped). Overturns the #1970
-  non-goal that forbade raising `ai.max_cost_usd`.
+  (`LINTRO_AI_MAX_COST_USD` / `--max-cost-usd`). Overturns the #1970 non-goal that
+  forbade raising `ai.max_cost_usd`. Overlay `0` = uncapped here is superseded by
+  [#2154](https://github.com/lgtm-hq/py-lintro/issues/2154) / ADR-0007 (`uncapped`
+  sentinel; overlay `0` rejected).
 - [#1923](https://github.com/lgtm-hq/py-lintro/issues/1923) — transport profiles must
   extend the same resolver.
 - [#1885](https://github.com/lgtm-hq/py-lintro/issues/1885) — provider-side `aclose()`

--- a/docs/ai-features.md
+++ b/docs/ai-features.md
@@ -684,7 +684,7 @@ as the legacy `ai.max_cost_usd` scalar.
 | `LINTRO_AI_TRANSPORT` / `--transport`                     | `ai.transport`    | `api` or `cli`                                                                               |
 | `LINTRO_AI_ENABLED`                                       | `ai.enabled`      | `1`/`0`/`true`/`false`. `=1` does not turn on `ai.review` or `ai.lint`. No `--enabled` flag. |
 | `LINTRO_AI_REVIEW` / `lintro review --review/--no-review` | `ai.review`       | `1`/`0`/`true`/`false`. The master `ai.enabled` switch must also be on.                      |
-| `LINTRO_AI_MAX_COST_USD` / `lintro review --max-cost-usd` | `ai.max_cost_usd` | Positive float = USD cap. Overlay **`uncapped`** lifts the ceiling. Overlay **`0` is rejected** as ambiguous (YAML `0` is $0). Invalid fails loud. |
+| `LINTRO_AI_MAX_COST_USD` / `lintro review --max-cost-usd` | `ai.max_cost_usd` | USD cap. Overlay `uncapped` lifts. Overlay `0` is rejected (YAML `0` is $0).                 |
 
 Unset variables are absent (fall through). Invalid values fail at resolution with a
 message naming the variable and the accepted values — they never silently use the config

--- a/docs/ai-features.md
+++ b/docs/ai-features.md
@@ -684,7 +684,7 @@ as the legacy `ai.max_cost_usd` scalar.
 | `LINTRO_AI_TRANSPORT` / `--transport`                     | `ai.transport`    | `api` or `cli`                                                                               |
 | `LINTRO_AI_ENABLED`                                       | `ai.enabled`      | `1`/`0`/`true`/`false`. `=1` does not turn on `ai.review` or `ai.lint`. No `--enabled` flag. |
 | `LINTRO_AI_REVIEW` / `lintro review --review/--no-review` | `ai.review`       | `1`/`0`/`true`/`false`. The master `ai.enabled` switch must also be on.                      |
-| `LINTRO_AI_MAX_COST_USD` / `lintro review --max-cost-usd` | `ai.max_cost_usd` | Positive float = USD cap. Overlay **`0` = uncapped** (YAML `0` is $0). Invalid fails loud.   |
+| `LINTRO_AI_MAX_COST_USD` / `lintro review --max-cost-usd` | `ai.max_cost_usd` | Positive float = USD cap. Overlay **`uncapped`** lifts the ceiling. Overlay **`0` is rejected** as ambiguous (YAML `0` is $0). Invalid fails loud. |
 
 Unset variables are absent (fall through). Invalid values fail at resolution with a
 message naming the variable and the accepted values — they never silently use the config
@@ -698,9 +698,9 @@ LINTRO_AI_PROVIDER=cursor LINTRO_AI_TRANSPORT=cli lintro review --uncommitted
 # Same thing with flags (flags win if both are set)
 lintro review --uncommitted --provider cursor --model cursor-grok-4.6-high --transport cli
 
-# Lift the committed cost cap for this run (0 = uncapped, not a $0 cap)
-LINTRO_AI_MAX_COST_USD=0 lintro review --uncommitted
-lintro review --uncommitted --max-cost-usd 0
+# Lift the committed cost cap for this run (`uncapped`; overlay `0` is an error)
+LINTRO_AI_MAX_COST_USD=uncapped lintro review --uncommitted
+lintro review --uncommitted --max-cost-usd uncapped
 
 # Kill switch for this environment
 LINTRO_AI_ENABLED=0 lintro check .

--- a/docs/ai-features.md
+++ b/docs/ai-features.md
@@ -698,7 +698,7 @@ LINTRO_AI_PROVIDER=cursor LINTRO_AI_TRANSPORT=cli lintro review --uncommitted
 # Same thing with flags (flags win if both are set)
 lintro review --uncommitted --provider cursor --model cursor-grok-4.6-high --transport cli
 
-# Lift the committed cost cap for this run (`uncapped`; overlay `0` is an error)
+# Run without a cost cap (`uncapped`; overlay `0` is an error)
 LINTRO_AI_MAX_COST_USD=uncapped lintro review --uncommitted
 lintro review --uncommitted --max-cost-usd uncapped
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -488,7 +488,7 @@ export LINTRO_AI_MODEL=cursor-grok-4.6-high
 export LINTRO_AI_TRANSPORT=cli
 export LINTRO_AI_ENABLED=1
 export LINTRO_AI_REVIEW=1
-export LINTRO_AI_MAX_COST_USD=0 # 0 = uncapped; a positive number is a USD cap
+export LINTRO_AI_MAX_COST_USD=uncapped # sentinel; a positive number is a USD cap; overlay 0 is an error
 ```
 
 | Variable                         | Description                                                       | Default   |
@@ -503,7 +503,7 @@ export LINTRO_AI_MAX_COST_USD=0 # 0 = uncapped; a positive number is a USD cap
 | `LINTRO_AI_TRANSPORT`            | Override `ai.transport` (`api` / `cli`)                           | -         |
 | `LINTRO_AI_ENABLED`              | Override `ai.enabled` (`1`/`0`/`true`/`false`)                    | -         |
 | `LINTRO_AI_REVIEW`               | Override `ai.review` (`1`/`0`/`true`/`false`)                     | -         |
-| `LINTRO_AI_MAX_COST_USD`         | Override `ai.max_cost_usd` (positive USD cap; **`0` = uncapped**) | -         |
+| `LINTRO_AI_MAX_COST_USD`         | Override `ai.max_cost_usd` (positive USD cap; **`uncapped`** lifts; overlay **`0` is an error**) | -         |
 
 > **Note:** There is no environment variable for tool timeouts, verbosity, exclude
 > patterns, output format, or auto-install. Use CLI flags (`--exclude`,
@@ -2993,7 +2993,7 @@ ai:
 | `max_fix_attempts`      | int    | `20`           | Max issues to attempt fixing per run                                                         |
 | `max_parallel_calls`    | int    | `5`            | Concurrent AI calls (1-20); honored with a cost cap; n−1 overshoot possible                  |
 | `max_retries`           | int    | `2`            | Max retries for transient errors (0-10)                                                      |
-| `max_cost_usd`          | float  | `null`         | Legacy USD cap; prefer profiles. Overlay `0` = uncapped (YAML `0` is $0)                     |
+| `max_cost_usd`          | float  | `null`         | Legacy USD cap; prefer profiles. Overlay `uncapped` lifts; overlay `0` is an error (YAML `0` is $0) |
 | `api_timeout`           | float  | `60.0`         | Legacy timeout (s); prefer `transports.*.timeout`                                            |
 | `transports`            | object | empty profiles | Per-transport profiles (`api` / `cli`) — see [AI review transports](ai-review-transports.md) |
 | `validate_after_group`  | bool   | `false`        | Validate immediately after each accepted group                                               |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2983,7 +2983,7 @@ ai:
 | `enabled`               | bool   | `false`        | Master switch; ANDs with `lint` / `review`                                                   |
 | `lint`                  | bool   | `false`        | Enable AI lint summaries on `chk`/`fmt`                                                      |
 | `review`                | bool   | `false`        | Enable the `lintro review` AI diff review                                                    |
-| `provider`              | string | `anthropic`    | AI provider (`anthropic` or `openai`)                                                        |
+| `provider`              | string | `anthropic`    | AI provider (`anthropic`, `openai`, or `cursor`)                                             |
 | `model`                 | string | (default)      | Model override                                                                               |
 | `api_key_env`           | string | (default)      | Custom env var for API key                                                                   |
 | `default_fix`           | bool   | `false`        | Always run `--fix` in check                                                                  |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -491,19 +491,19 @@ export LINTRO_AI_REVIEW=1
 export LINTRO_AI_MAX_COST_USD=uncapped # sentinel; a positive number is a USD cap; overlay 0 is an error
 ```
 
-| Variable                         | Description                                                       | Default   |
-| -------------------------------- | ----------------------------------------------------------------- | --------- |
-| `LINTRO_LOG_DIR`                 | Base directory for run logs and artifacts                         | `.lintro` |
-| `LINTRO_VERSION_TIMEOUT`         | Timeout in seconds for tool version checks (must be `>= 1`)       | `30`      |
-| `LINTRO_DOCKER`                  | Force Docker install-context detection when set to `1`            | -         |
-| `LINTRO_CONFIG`                  | Shown in the `lintro` environment report; informational only      | -         |
-| `LINTRO_ENABLE_EXTERNAL_PLUGINS` | Opt in to loading external (third-party) plugins (`1`/`0`)        | `0`       |
-| `LINTRO_AI_PROVIDER`             | Override `ai.provider` (`anthropic` / `openai` / `cursor`)        | -         |
-| `LINTRO_AI_MODEL`                | Override `ai.model`                                               | -         |
-| `LINTRO_AI_TRANSPORT`            | Override `ai.transport` (`api` / `cli`)                           | -         |
-| `LINTRO_AI_ENABLED`              | Override `ai.enabled` (`1`/`0`/`true`/`false`)                    | -         |
-| `LINTRO_AI_REVIEW`               | Override `ai.review` (`1`/`0`/`true`/`false`)                     | -         |
-| `LINTRO_AI_MAX_COST_USD`         | Override `ai.max_cost_usd` (positive USD cap; **`uncapped`** lifts; overlay **`0` is an error**) | -         |
+| Variable                         | Description                                                  | Default   |
+| -------------------------------- | ------------------------------------------------------------ | --------- |
+| `LINTRO_LOG_DIR`                 | Base directory for run logs and artifacts                    | `.lintro` |
+| `LINTRO_VERSION_TIMEOUT`         | Timeout in seconds for tool version checks (must be `>= 1`)  | `30`      |
+| `LINTRO_DOCKER`                  | Force Docker install-context detection when set to `1`       | -         |
+| `LINTRO_CONFIG`                  | Shown in the `lintro` environment report; informational only | -         |
+| `LINTRO_ENABLE_EXTERNAL_PLUGINS` | Opt in to loading external (third-party) plugins (`1`/`0`)   | `0`       |
+| `LINTRO_AI_PROVIDER`             | Override `ai.provider` (`anthropic` / `openai` / `cursor`)   | -         |
+| `LINTRO_AI_MODEL`                | Override `ai.model`                                          | -         |
+| `LINTRO_AI_TRANSPORT`            | Override `ai.transport` (`api` / `cli`)                      | -         |
+| `LINTRO_AI_ENABLED`              | Override `ai.enabled` (`1`/`0`/`true`/`false`)               | -         |
+| `LINTRO_AI_REVIEW`               | Override `ai.review` (`1`/`0`/`true`/`false`)                | -         |
+| `LINTRO_AI_MAX_COST_USD`         | Override `ai.max_cost_usd` (USD cap or `uncapped`)           | -         |
 
 > **Note:** There is no environment variable for tool timeouts, verbosity, exclude
 > patterns, output format, or auto-install. Use CLI flags (`--exclude`,
@@ -2993,7 +2993,7 @@ ai:
 | `max_fix_attempts`      | int    | `20`           | Max issues to attempt fixing per run                                                         |
 | `max_parallel_calls`    | int    | `5`            | Concurrent AI calls (1-20); honored with a cost cap; n−1 overshoot possible                  |
 | `max_retries`           | int    | `2`            | Max retries for transient errors (0-10)                                                      |
-| `max_cost_usd`          | float  | `null`         | Legacy USD cap; prefer profiles. Overlay `uncapped` lifts; overlay `0` is an error (YAML `0` is $0) |
+| `max_cost_usd`          | float  | `null`         | Legacy USD cap; prefer profiles. Overlay `uncapped` lifts; overlay `0` is an error           |
 | `api_timeout`           | float  | `60.0`         | Legacy timeout (s); prefer `transports.*.timeout`                                            |
 | `transports`            | object | empty profiles | Per-transport profiles (`api` / `cli`) — see [AI review transports](ai-review-transports.md) |
 | `validate_after_group`  | bool   | `false`        | Validate immediately after each accepted group                                               |

--- a/docs/github-integration.md
+++ b/docs/github-integration.md
@@ -66,13 +66,15 @@ workflow runs an AI diff review and prints the JSON result to the job log.
   PR that breaks the review code itself isn't caught by this job — that is covered by
   the unit tests.
 - 🔑 **Bring-your-own credential** — runs the `cli` transport. Provider and model come
-  from the `LINTRO_AI_PROVIDER` / `LINTRO_AI_MODEL` Actions variables (dogfood: `cursor`
-  - `cursor-grok-4.6-high`). Cursor uses `CURSOR_API_KEY`; Anthropic uses the pinned
-    `claude` CLI authenticated by `CLAUDE_CODE_OAUTH_TOKEN` (a Claude subscription
-    session). `ANTHROPIC_API_KEY` is deliberately **not** in scope, and
-    `LINTRO_CLI_BARE: never` keeps `--bare` off the command line so an OAuth session is
-    actually used (#1838). CLI versions are pinned in `docker/ai-tools.Dockerfile` and
-    installed from npm at those exact versions.
+  from the `LINTRO_AI_PROVIDER` / `LINTRO_AI_MODEL` Actions variables. When those
+  variables are unset the workflow falls through to the committed defaults (`anthropic`,
+  empty model). Operators can set them to `cursor` and `cursor-grok-4.6-high` for
+  current dogfood. Cursor uses `CURSOR_API_KEY`; Anthropic uses the pinned `claude` CLI
+  authenticated by `CLAUDE_CODE_OAUTH_TOKEN` (a Claude subscription session).
+  `ANTHROPIC_API_KEY` is deliberately **not** in scope, and `LINTRO_CLI_BARE: never`
+  keeps `--bare` off the command line so an OAuth session is actually used (#1838). CLI
+  versions are pinned in `docker/ai-tools.Dockerfile` and installed from npm at those
+  exact versions.
 - 💸 **Operator-set spend ceiling (advisory under the CLI transport)** — the trusted
   base config ships **no** `ai.max_cost_usd`, so there is no committed default cap. A PR
   still cannot raise spend: the workflow installs lintro from the base ref and forwards
@@ -94,9 +96,10 @@ workflow runs an AI diff review and prints the JSON result to the job log.
   read secrets) never start the job at all.
 
 To activate it, add the matching secret (**Settings → Secrets and variables →
-Actions**): `CURSOR_API_KEY` for Cursor, or `CLAUDE_CODE_OAUTH_TOKEN` (mint with
-`claude setup-token`) for Anthropic. Because reviews run using trusted base-branch
-lintro, the credential is safe to enable.
+Actions**): `CURSOR_API_KEY` plus `LINTRO_AI_PROVIDER=cursor` (and optionally
+`LINTRO_AI_MODEL` / `LINTRO_AI_MAX_COST_USD=uncapped`) for Cursor, or
+`CLAUDE_CODE_OAUTH_TOKEN` (mint with `claude setup-token`) for Anthropic. Because
+reviews run using lintro from the trusted base branch, the credential is safe to enable.
 
 #### Activation precondition (security audit #1317)
 
@@ -108,8 +111,9 @@ all three controls (also asserted in `tests/scripts/test_run_ai_review.py`):
 2. **Trusted install** — the checkout step uses `pull_request.base.sha`, never the PR
    head, so code that runs with the credential is always from the trusted base ref. The
    `claude` CLI is installed at a version pinned in that same trusted checkout.
-3. **Secret ordering** — `CLAUDE_CODE_OAUTH_TOKEN` is injected only into the final
-   review step's `env`, after checkout, the CLI install, and dependency install.
+3. **Secret ordering** — `CLAUDE_CODE_OAUTH_TOKEN` and `CURSOR_API_KEY` are injected
+   only into the final review step's `env`, after checkout, the CLI install, and
+   dependency install.
 
 These controls landed with #1074; #1317 verified them against current `main`. A
 dedicated GitHub Environment with required reviewers is optional once (1–3) hold. Re-run

--- a/docs/github-integration.md
+++ b/docs/github-integration.md
@@ -73,8 +73,9 @@ workflow runs an AI diff review and prints the JSON result to the job log.
   installed from npm at that exact version.
 - 💸 **Bounded spend (advisory under the CLI transport)** — `ai.max_cost_usd` defaults
   to the trusted base config, so a PR cannot raise the cap. Repository operators can
-  override that default with the `LINTRO_AI_MAX_COST_USD` Actions variable (`0` means
-  uncapped). It prices only the tokens lintro billed itself, so on the `cli` transport —
+  override that default with the `LINTRO_AI_MAX_COST_USD` Actions variable (`uncapped`
+  lifts the ceiling; overlay `0` is rejected as ambiguous). It prices only the tokens
+  lintro billed itself, so on the `cli` transport —
   where the call bills the subscription — it bounds lintro's own accounting rather than
   enforcing spend. Setting a cap does **not** serialize provider calls: the budget
   checks and charges the ceiling around each call rather than holding a lock across it,

--- a/docs/github-integration.md
+++ b/docs/github-integration.md
@@ -65,23 +65,26 @@ workflow runs an AI diff review and prints the JSON result to the job log.
   the PR's changes are reviewed as data and never executed with the secret. Trade-off: a
   PR that breaks the review code itself isn't caught by this job — that is covered by
   the unit tests.
-- 🔑 **Bring-your-own credential** — runs the `cli` transport against the pinned
-  `claude` CLI, authenticated by the `CLAUDE_CODE_OAUTH_TOKEN` secret (a Claude
-  subscription session). `ANTHROPIC_API_KEY` is deliberately **not** in scope, and
-  `LINTRO_CLI_BARE: never` keeps `--bare` off the command line so the OAuth session is
-  actually used (#1838). The CLI version is pinned in `docker/ai-tools.Dockerfile` and
-  installed from npm at that exact version.
-- 💸 **Bounded spend (advisory under the CLI transport)** — `ai.max_cost_usd` defaults
-  to the trusted base config, so a PR cannot raise the cap. Repository operators can
-  override that default with the `LINTRO_AI_MAX_COST_USD` Actions variable (`uncapped`
-  lifts the ceiling; overlay `0` is rejected as ambiguous). It prices only the tokens
-  lintro billed itself, so on the `cli` transport — where the call bills the
-  subscription — it bounds lintro's own accounting rather than enforcing spend. Setting
-  a cap does **not** serialize provider calls: the budget checks and charges the ceiling
-  around each call rather than holding a lock across it, so budgeted chunk reviews still
-  run concurrently. The trade-off is that calls already in flight when the ceiling is
-  reached still finish, so the final total can overshoot `ai.max_cost_usd` by roughly
-  one round of concurrent calls.
+- 🔑 **Bring-your-own credential** — runs the `cli` transport. Provider and model come
+  from the `LINTRO_AI_PROVIDER` / `LINTRO_AI_MODEL` Actions variables (dogfood: `cursor`
+  - `cursor-grok-4.6-high`). Cursor uses `CURSOR_API_KEY`; Anthropic uses the pinned
+    `claude` CLI authenticated by `CLAUDE_CODE_OAUTH_TOKEN` (a Claude subscription
+    session). `ANTHROPIC_API_KEY` is deliberately **not** in scope, and
+    `LINTRO_CLI_BARE: never` keeps `--bare` off the command line so an OAuth session is
+    actually used (#1838). CLI versions are pinned in `docker/ai-tools.Dockerfile` and
+    installed from npm at those exact versions.
+- 💸 **Operator-set spend ceiling (advisory under the CLI transport)** — the trusted
+  base config ships **no** `ai.max_cost_usd`, so there is no committed default cap. A PR
+  still cannot raise spend: the workflow installs lintro from the base ref and forwards
+  `LINTRO_AI_MAX_COST_USD` from the repository Actions variable. Operators set that
+  variable to a positive USD cap or to `uncapped` (overlay `0` is rejected as
+  ambiguous). It prices only the tokens lintro billed itself, so on the `cli` transport
+  — where the call bills the subscription — it bounds lintro's own accounting rather
+  than enforcing spend. Setting a cap does **not** serialize provider calls: the budget
+  checks and charges the ceiling around each call rather than holding a lock across it,
+  so budgeted chunk reviews still run concurrently. The trade-off is that calls already
+  in flight when the ceiling is reached still finish, so the final total can overshoot
+  `ai.max_cost_usd` by roughly one round of concurrent calls.
 - 🟡 **Loud but non-blocking** — the check is deliberately **not** required, but it is
   not unconditionally green either: it reddens whenever no review was produced (missing
   or dead credential, depleted balance, unreachable provider, lintro-side failure). See
@@ -90,9 +93,10 @@ workflow runs an AI diff review and prints the JSON result to the job log.
 - ⏭️ **Skipped, not failed, where it cannot run** — draft PRs and fork PRs (which cannot
   read secrets) never start the job at all.
 
-To activate it, add a `CLAUDE_CODE_OAUTH_TOKEN` secret to the repository or organization
-(**Settings → Secrets and variables → Actions**). Mint one with `claude setup-token`.
-Because reviews run using trusted base-branch lintro, the token is safe to enable.
+To activate it, add the matching secret (**Settings → Secrets and variables →
+Actions**): `CURSOR_API_KEY` for Cursor, or `CLAUDE_CODE_OAUTH_TOKEN` (mint with
+`claude setup-token`) for Anthropic. Because reviews run using trusted base-branch
+lintro, the credential is safe to enable.
 
 #### Activation precondition (security audit #1317)
 

--- a/docs/github-integration.md
+++ b/docs/github-integration.md
@@ -75,13 +75,13 @@ workflow runs an AI diff review and prints the JSON result to the job log.
   to the trusted base config, so a PR cannot raise the cap. Repository operators can
   override that default with the `LINTRO_AI_MAX_COST_USD` Actions variable (`uncapped`
   lifts the ceiling; overlay `0` is rejected as ambiguous). It prices only the tokens
-  lintro billed itself, so on the `cli` transport —
-  where the call bills the subscription — it bounds lintro's own accounting rather than
-  enforcing spend. Setting a cap does **not** serialize provider calls: the budget
-  checks and charges the ceiling around each call rather than holding a lock across it,
-  so budgeted chunk reviews still run concurrently. The trade-off is that calls already
-  in flight when the ceiling is reached still finish, so the final total can overshoot
-  `ai.max_cost_usd` by roughly one round of concurrent calls.
+  lintro billed itself, so on the `cli` transport — where the call bills the
+  subscription — it bounds lintro's own accounting rather than enforcing spend. Setting
+  a cap does **not** serialize provider calls: the budget checks and charges the ceiling
+  around each call rather than holding a lock across it, so budgeted chunk reviews still
+  run concurrently. The trade-off is that calls already in flight when the ceiling is
+  reached still finish, so the final total can overshoot `ai.max_cost_usd` by roughly
+  one round of concurrent calls.
 - 🟡 **Loud but non-blocking** — the check is deliberately **not** required, but it is
   not unconditionally green either: it reddens whenever no review was produced (missing
   or dead credential, depleted balance, unreachable provider, lintro-side failure). See

--- a/tests/scripts/test_run_ai_review.py
+++ b/tests/scripts/test_run_ai_review.py
@@ -120,9 +120,10 @@ def test_committed_config_keeps_ai_off_with_review_ready() -> None:
 
     ``ai.review: true`` is committed so enabling the master switch does not
     rely on the deprecated implied-sub-toggle path. ``ai.max_cost_usd`` is
-    unset after the #2156 rollout (no committed cap; CI overlays
-    ``LINTRO_AI_MAX_COST_USD=uncapped``). Historical: #2018 / 9f43a98a
-    briefly shipped 0.50; #2025 restored 2.00 as the interim committed cap.
+    unset after the #2156 rollout (no committed cap; CI forwards
+    ``LINTRO_AI_MAX_COST_USD``, and dogfood operators set ``uncapped``).
+    Historical: #2018 / 9f43a98a briefly shipped 0.50; #2025 restored 2.00 as
+    the interim committed cap.
     """
     loaded = yaml.safe_load(PROJECT_CONFIG.read_text(encoding="utf-8"))
     ai_section = loaded["ai"]

--- a/tests/scripts/test_run_ai_review.py
+++ b/tests/scripts/test_run_ai_review.py
@@ -119,17 +119,20 @@ def test_committed_config_keeps_ai_off_with_review_ready() -> None:
     """Local default stays AI-off; CI turns it on via ``LINTRO_AI_ENABLED=1``.
 
     ``ai.review: true`` is committed so enabling the master switch does not
-    rely on the deprecated implied-sub-toggle path. ``ai.max_cost_usd`` is the
-    spend ceiling (2.00; restored by #2025 after the 0.50 side-effect in
-    #2018 / 9f43a98a).
+    rely on the deprecated implied-sub-toggle path. ``ai.max_cost_usd`` is
+    unset after the #2156 rollout (no committed cap; CI overlays
+    ``LINTRO_AI_MAX_COST_USD=uncapped``). Historical: #2018 / 9f43a98a
+    briefly shipped 0.50; #2025 restored 2.00 as the interim committed cap.
     """
     loaded = yaml.safe_load(PROJECT_CONFIG.read_text(encoding="utf-8"))
     ai_section = loaded["ai"]
     assert_that(ai_section["enabled"]).is_false()
     assert_that(ai_section["review"]).is_true()
-    assert_that(ai_section["max_cost_usd"]).is_equal_to(2.00)
+    assert_that(ai_section).does_not_contain_key("max_cost_usd")
     workflow_text = WORKFLOW.read_text(encoding="utf-8")
     assert_that(workflow_text).contains("#2018 / 9f43a98a")
+    assert_that(workflow_text).contains("LINTRO_AI_MAX_COST_USD")
+    assert_that(workflow_text).does_not_contain("|| '2.00'")
     assert_that(workflow_text).does_not_contain("0.50 that landed with\n# #1971")
 
 

--- a/tests/unit/ai/test_config_overrides.py
+++ b/tests/unit/ai/test_config_overrides.py
@@ -352,7 +352,7 @@ def test_max_cost_usd_overlay_zero_is_rejected(
 
 
 def test_yaml_zero_is_a_zero_dollar_cap_not_uncapped() -> None:
-    """Committed YAML ``0`` is a $0 cap; only overlay ``0`` is uncapped (#2024)."""
+    """Committed YAML ``0`` is a $0 cap; overlay ``0`` is rejected (#2154)."""
     resolved = AIConfig.resolve_from_mapping(_mapping(max_cost_usd=0))
 
     assert_that(resolved.config.max_cost_usd).is_equal_to(0.0)

--- a/tests/unit/ai/test_config_overrides.py
+++ b/tests/unit/ai/test_config_overrides.py
@@ -352,7 +352,7 @@ def test_max_cost_usd_overlay_zero_is_rejected(
 
 
 def test_yaml_zero_is_a_zero_dollar_cap_not_uncapped() -> None:
-    """Committed YAML ``0`` is a $0 cap; overlay ``0`` is rejected (#2154)."""
+    """Committed YAML ``0`` is a $0 cap (#2024). Overlay rejection is separate."""
     resolved = AIConfig.resolve_from_mapping(_mapping(max_cost_usd=0))
 
     assert_that(resolved.config.max_cost_usd).is_equal_to(0.0)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  chore(ai): drop committed cost cap for uncapped dogfood
  ```

- Type:
  - [x] chore / ci / style
  - [ ] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type or a body containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What’s Changing

Epic #2156 step 6 (rollout). Removes the committed `ai.max_cost_usd: 2.00` so dogfood has no committed ceiling. Overlay `0` stays a hard error; YAML `0` stays a literal $0 cap. Docs that still said overlay `0` = uncapped now match ADR-0007 (`uncapped` sentinel).

**#2156 step 5 is recorded on #2165** (quiet re-review: `reviewed=0`, `carried=41`, zero provider calls).

**Repo Actions variables could not be written from this token (HTTP 403).** An operator still needs to set:

- `LINTRO_AI_MAX_COST_USD=uncapped` — live dogfood currently overlays `1000`
- `LINTRO_AI_PROVIDER=cursor` — already observed live
- `LINTRO_AI_MODEL=cursor-grok-4.6-high` — already observed live

Do not add a `|| '2.00'` workflow fallback. Stay draft and do not merge until Docker dogfood is green.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [x] Docs updated if user-facing
- [x] Local contract tests passed (`tests/scripts/test_run_ai_review.py`)

## Related Issues

Related #2156

## Details

Workflow comments no longer claim a committed $2.00 default. The contract test asserts the key is absent and that `ai-review.yml` does not contain `|| '2.00'`. Follow-up commits: prettier/MD060 for dogfood lint (`79dd6873`); review-driven wording (`7c3b2d61`).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0ff3c26c-cf67-4c32-bff9-30643bc047b9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0ff3c26c-cf67-4c32-bff9-30643bc047b9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * AI Review now supports configurable Cursor and Anthropic providers and models.
  * Operators can set spend limits using a positive USD value or `uncapped`.
  * Activation guidance includes provider-specific credentials.

* **Bug Fixes**
  * Clarified zero-dollar limits: YAML `0` remains valid, while overlay `0` is rejected.

* **Documentation**
  * Updated configuration, workflow, AI feature, integration, and changelog documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->