### PR TITLE
fix(ai): raise default CLI timeout to 1800s

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -123,17 +123,18 @@ jobs:
       # Cross-run artifact listing / download-artifact with run-id uses
       # the workflow GITHUB_TOKEN (#2158). Upload uses the same token.
       actions: read
-    # COUPLED to ai.transports.cli.timeout (default 900 s,
+    # COUPLED to ai.transports.cli.timeout (default 1800 s,
     # lintro.ai.transport.DEFAULT_CLI_TIMEOUT): the
-    # job budget must cover setup (~7 min) + the full review timeout (15 min) +
-    # posting margin, so lintro's own timeout always fires before the runner
-    # kills the job — a runner kill truncates the JSON envelope the outcome
-    # classifier reads. Invariant enforced by tests/scripts/
-    # test_run_ai_review.py; bump both values together. 75 (was 30, then 50) because
-    # custom-agent passes stack additional per-call --timeout budgets on top
-    # of the main review call, and provider-heavy diffs were hitting the old
-    # ceiling exactly (#1976 reviews killed at the boundary four times; #1977's
-    # oscillated around 45-55 min and was killed at 50 twice).
+    # job budget must cover setup (~7 min) + one per-chunk CLI timeout
+    # (30 min) + posting margin, so lintro's own timeout always fires before
+    # the runner kills the job — a runner kill truncates the JSON envelope
+    # the outcome classifier reads. Invariant enforced by tests/scripts/
+    # test_run_ai_review.py; bump both values together. 75 (was 30, then 50)
+    # because custom-agent passes stack additional per-call --timeout budgets
+    # on top of the main review call, and provider-heavy diffs were hitting
+    # the old ceiling exactly (#1976 reviews killed at the boundary four
+    # times; #1977's oscillated around 45-55 min and was killed at 50 twice).
+    # 1800s is one chunk, not the whole serial run.
     timeout-minutes: 75
     # Cursor shards are appended only when the dogfood provider is Cursor.
     # They stay out of the anthropic path so that job cannot reach Cursor

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - **ai-review**: remove the committed `ai.max_cost_usd: 2.00` dogfood cap so CI can
   overlay `LINTRO_AI_MAX_COST_USD=uncapped` (#2156)
+- **ai**: raise the default CLI review timeout from 900s to 1800s so a large semantic
+  chunk can finish under serial dogfood (#2156)
 
 ### Deprecated
 

--- a/docs/ai-review-transports.md
+++ b/docs/ai-review-transports.md
@@ -10,7 +10,7 @@ and reported numbers mean different things. Configure them under `ai.transports.
 | ------------------- | ------------------------------------------- | ------------------------------------------------------------------------------------- |
 | Credential          | `ANTHROPIC_API_KEY` (or provider key)       | `CLAUDE_CODE_OAUTH_TOKEN` / `claude` login                                            |
 | Billing             | Metered API spend                           | Subscription / OAuth session                                                          |
-| Default timeout     | 60s (stream-sized per call)                 | 900s (whole-turn)                                                                     |
+| Default timeout     | 60s (stream-sized per call)                 | 1800s (per CLI chunk)                                                                 |
 | Cost cap field      | `ai.transports.api.max_cost_usd` (enforced) | `ai.transports.cli.max_cost_usd_advisory` (advisory)                                  |
 | Legacy fallback     | `ai.api_timeout`, `ai.max_cost_usd`         | `ai.max_cost_usd` for the advisory only                                               |
 | Auth mode recorded  | `api_key`                                   | `subscription`                                                                        |
@@ -39,7 +39,7 @@ Effective settings = **transport profile → legacy scalar → built-in default*
 `lintro review` logs the resolved profile at start, for example:
 
 ```text
-transport=cli auth=subscription timeout=900 cap=advisory:$0.50 cost_basis=unpriceable
+transport=cli auth=subscription timeout=1800 cap=advisory:$0.50 cost_basis=unpriceable
 ```
 
 ## Example config
@@ -54,7 +54,7 @@ ai:
       timeout: 60
       max_cost_usd: 0.50
     cli:
-      timeout: 900
+      timeout: 1800
       max_cost_usd_advisory: 0.50
 ```
 

--- a/lintro/ai/config.py
+++ b/lintro/ai/config.py
@@ -73,7 +73,7 @@ class CliTransportProfile(BaseModel):
     timeout: float | None = Field(
         default=None,
         ge=1.0,
-        description="Whole-turn timeout in seconds (default 900).",
+        description="Per-chunk CLI invocation timeout in seconds (default 1800).",
     )
     max_cost_usd_advisory: float | None = Field(
         default=None,
@@ -172,7 +172,7 @@ class AIConfig(BaseModel):
         description=(
             "Per-transport operational profiles (timeout and cost caps). "
             "Resolution: transport profile → legacy api_timeout/max_cost_usd "
-            "→ built-in default (api: 60s; cli: 900s)."
+            "→ built-in default (api: 60s; cli: 1800s)."
         ),
     )
     model: str | None = None

--- a/lintro/ai/transport.py
+++ b/lintro/ai/transport.py
@@ -29,7 +29,7 @@ __all__ = [
 ]
 
 DEFAULT_API_TIMEOUT = 60.0
-DEFAULT_CLI_TIMEOUT = 900.0
+DEFAULT_CLI_TIMEOUT = 1800.0
 
 AuthMode = Literal["api_key", "subscription", "unknown"]
 
@@ -40,7 +40,7 @@ class ResolvedTransportSettings:
 
     Attributes:
         transport: Active transport.
-        timeout: Per-call / whole-turn timeout in seconds.
+        timeout: Per-call / per-chunk timeout in seconds.
         max_cost_usd: Enforced or advisory cost ceiling (None = unlimited).
         cost_is_advisory: True when the cap cannot enforce spend (CLI/subscription).
         auth_mode: How the transport authenticates.
@@ -120,8 +120,8 @@ def resolve_transport_settings(ai_config: AIConfig) -> ResolvedTransportSettings
 
     if transport is AITransport.CLI:
         # Legacy ``ai.api_timeout`` is API-sized (60s default) and must not
-        # silently become the CLI whole-turn budget. CLI falls back to the
-        # CLI built-in (900s) when the profile omits timeout (#1923).
+        # silently become the CLI per-chunk budget. CLI falls back to the
+        # CLI built-in (1800s) when the profile omits timeout (#1923).
         timeout = (
             profiles.cli.timeout
             if profiles.cli.timeout is not None

--- a/scripts/ci/run-ai-review.sh
+++ b/scripts/ci/run-ai-review.sh
@@ -149,16 +149,17 @@ fi
 export LINTRO_REVIEW_STATE_DIR="${LINTRO_REVIEW_STATE_DIR:-ai-review-state}"
 mkdir -p "${LINTRO_REVIEW_STATE_DIR}"
 
-# Capture rather than stream: the classifier needs the JSON error envelope, and
-# the full output is echoed straight afterwards so the log is unchanged.
+# Tee to a file: the classifier needs the JSON error envelope, and the live
+# stream must still reach the Actions log so a mid-run SIGTERM is diagnosable.
 output_file="$(mktemp)"
 trap 'rm -f "$output_file"' EXIT
 
 set +e
-# Timeout comes from ai.transports.cli.timeout (default 900s) — no hand-tuned
+# Timeout comes from ai.transports.cli.timeout (default 1800s) — no hand-tuned
 # --timeout at this call site (#1923). The default ai.api_timeout (60s) is
-# sized for streaming API chunks; a CLI turn runs the whole review in one
-# agent invocation and needs minutes.
+# sized for streaming API chunks; a CLI chunk is one agent invocation and
+# needs minutes. Multi-chunk serial reviews (#2156 14-chunk dogfood) need
+# the 1800s per-call budget so a ~20k-token chunk can finish.
 #
 # COUPLED to ai-review.yml's `timeout-minutes`: the resolved CLI timeout must
 # fire BEFORE the Actions runner kills the job, or the review dies without a
@@ -171,12 +172,12 @@ set +e
 # must cover; tests/scripts/test_run_ai_review.py asserts it matches
 # lintro.ai.transport.DEFAULT_CLI_TIMEOUT.
 # shellcheck disable=SC2034  # documentation variable read by the wiring test
-CLI_REVIEW_TIMEOUT_SECONDS=900
-uv run lintro review --pr "${pr_number}" "${repo_arg[@]}" --depth 1 --post --output json >"$output_file" 2>&1
+CLI_REVIEW_TIMEOUT_SECONDS=1800
+# Unbuffered Python so the tee pipeline shows mid-chunk progress if SIGTERM'd.
+export PYTHONUNBUFFERED=1
+uv run lintro review --pr "${pr_number}" "${repo_arg[@]}" --depth 1 --post --output json 2>&1 | tee "$output_file"
 review_status=$?
 set -e
-
-cat "$output_file"
 
 # Exits 0 only when a review was produced; the classifier writes the annotation
 # and job summary either way. --transport names the failure vocabulary (#1923).

--- a/tests/scripts/test_run_ai_review.py
+++ b/tests/scripts/test_run_ai_review.py
@@ -1000,6 +1000,25 @@ def test_workflow_allows_the_npm_registry_egress() -> None:
     assert_that(endpoints_raw).contains("${{ env.AI_REVIEW_CURSOR_EGRESS }}")
 
 
+def test_run_ai_review_tees_under_pipefail() -> None:
+    """The review pipeline must tee output and fail when the CLI exits non-zero."""
+    shell_text = SHELL_SCRIPT.read_text(encoding="utf-8")
+    assert_that(shell_text).contains("set -euo pipefail")
+    assert_that(shell_text).contains("PYTHONUNBUFFERED=1")
+    assert_that(shell_text).contains('| tee "$output_file"')
+    result = subprocess.run(  # nosec B603 - fixed argv; shell=False
+        [
+            "bash",
+            "-c",
+            "set -euo pipefail; false | tee /dev/null",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert_that(result.returncode).is_not_equal_to(0)
+
+
 def test_review_timeout_fits_inside_the_job_timeout() -> None:
     """The CLI transport profile timeout fires before the job ``timeout-minutes``.
 

--- a/tests/scripts/test_run_ai_review.py
+++ b/tests/scripts/test_run_ai_review.py
@@ -1006,11 +1006,11 @@ def test_run_ai_review_tees_under_pipefail() -> None:
     assert_that(shell_text).contains("set -euo pipefail")
     assert_that(shell_text).contains("PYTHONUNBUFFERED=1")
     assert_that(shell_text).contains('| tee "$output_file"')
-    result = subprocess.run(  # nosec B603 - fixed argv; shell=False
+    result = subprocess.run(  # nosec B603 B607 - fixed bash argv in a controlled test; binary name resolved from PATH, not attacker-controlled; shell=False
         [
             "bash",
             "-c",
-            "set -euo pipefail; false | tee /dev/null",
+            'set -euo pipefail; set +e; false | tee /dev/null; status=$?; exit "$status"',
         ],
         check=False,
         capture_output=True,

--- a/tests/unit/ai/test_transport_profiles.py
+++ b/tests/unit/ai/test_transport_profiles.py
@@ -34,7 +34,7 @@ def _isolate_bare_mode_env(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_cli_defaults_to_whole_turn_timeout() -> None:
-    """CLI without a profile uses the 900s whole-turn default."""
+    """CLI without a profile uses the 1800s per-chunk default."""
     config = AIConfig(enabled=True, transport=AITransport.CLI)
     resolved = resolve_transport_settings(config)
     assert_that(resolved.timeout).is_equal_to(DEFAULT_CLI_TIMEOUT)

--- a/tests/unit/ai/test_transport_profiles.py
+++ b/tests/unit/ai/test_transport_profiles.py
@@ -33,7 +33,7 @@ def _isolate_bare_mode_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("LINTRO_CLI_BARE", raising=False)
 
 
-def test_cli_defaults_to_whole_turn_timeout() -> None:
+def test_cli_defaults_to_per_chunk_timeout() -> None:
     """CLI without a profile uses the 1800s per-chunk default."""
     config = AIConfig(enabled=True, transport=AITransport.CLI)
     resolved = resolve_transport_settings(config)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(ai): raise default CLI timeout to 1800s
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

### Release Trigger Rules (exact)

- A merged PR will bump the version based on its title (squash merge required):
  - `feat(...)` or `feat:` → MINOR bump
  - `fix(...)` / `fix:` or `perf(...)` / `perf:` → PATCH bump
  - Any title with `!` after the type (e.g. `feat!:` or `feat(scope)!:`) or a body
    containing `BREAKING CHANGE:` → MAJOR bump
- Use squash merge so the PR title becomes the merge commit title.

## What’s Changing

`pull_request_target` AI Review installs lintro from `pull_request.base.sha`. #2167 cannot dogfood its own 1800s persist path: two HEAD runs (32774629039, 32777216794) downloaded the last successful artifact, then the review step was cancelled at ~19 min under main's 900s CLI budget. Artifact upload skipped.

This PR is the unblocker only:

1. Raise `DEFAULT_CLI_TIMEOUT` and `CLI_REVIEW_TIMEOUT_SECONDS` from 900s to 1800s (job `timeout-minutes: 75` already covers one per-chunk budget + setup).
2. Tee the review log with `PYTHONUNBUFFERED=1` so a mid-run SIGTERM is diagnosable.
3. Document the default as per-chunk, not whole-turn.

No persist / timeout-as-partial / finding-replay changes. Those stay on #2167.

Related: #2156, #2167, #2166.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [x] Docs updated if user-facing
- [x] Local CI passed (`pytest` on timeout coupling, tee, transport profiles, changelog)

## Related Issues

Related #2156

## Details

After this merges, rebase/merge main into #2167 so its next dogfood run installs 1800s from `base.sha`. Then #2166 can be retriggered. Do not merge #2165/#2166 as terraform/SPDX.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0ff3c26c-cf67-4c32-bff9-30643bc047b9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0ff3c26c-cf67-4c32-bff9-30643bc047b9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Increased the default AI review timeout to 1,800 seconds per CLI chunk, improving support for larger reviews.
  * AI review progress is now streamed to CI logs while results remain available for status reporting.

* **Documentation**
  * Updated workflow, configuration, transport, and changelog documentation to reflect per-chunk timeout behavior and the existing overall job limit.

* **Tests**
  * Added coverage confirming streamed output, unbuffered logging, and proper failure-status propagation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->