### PR TITLE
fix(ai-review): persist coverage when the runner sends SIGTERM

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -353,6 +353,8 @@ jobs:
         # 97293667852, 2026-08-24). Incremental ``state.json`` writes
         # (#2154/#2156) are runner-local until this step; they survive
         # SIGTERM of the review process, not a skipped always() upload.
+        # lintro now traps SIGTERM, writes state.json, and exits with a
+        # JSON envelope so this step can still run after a runner signal.
         # if-no-files-found: ignore so pre-feature runs no-op.
         if: always()
         # yamllint disable-line rule:line-length

--- a/lintro/ai/providers/cli_transport.py
+++ b/lintro/ai/providers/cli_transport.py
@@ -24,6 +24,7 @@ import json
 import os
 import re
 import shutil
+import signal
 import subprocess  # nosec B404 - subprocess is the core mechanism for invoking external tools; all invocations use shell=False
 import threading
 from abc import ABC, abstractmethod
@@ -101,11 +102,19 @@ def flag_named_in(lowered_text: str, flag: str) -> bool:
 
 
 async def _terminate(process: asyncio.subprocess.Process) -> None:
-    """Kill a child process and reap it so it cannot linger as a zombie.
+    """Kill a child process (and its session) so it cannot linger as a zombie.
+
+    The child is started with ``start_new_session=True`` so an agent
+    ``killpg`` cannot take lintro with it. Termination therefore has to
+    signal that new process group, not only the direct child pid.
 
     Args:
         process: The child process to stop.
     """
+    pid = getattr(process, "pid", None)
+    if pid is not None and os.name == "posix":
+        with contextlib.suppress(ProcessLookupError, PermissionError, OSError):
+            os.killpg(pid, signal.SIGKILL)
     with contextlib.suppress(ProcessLookupError):
         process.kill()
     with contextlib.suppress(ProcessLookupError):
@@ -662,6 +671,10 @@ class CliTransport(ABC):
             stdin=input_text,
         ) as record:
             try:
+                spawn_kwargs: dict[str, Any] = {}
+                if os.name == "posix":
+                    # New session: the agent CLI cannot killpg lintro (#2156).
+                    spawn_kwargs["start_new_session"] = True
                 process = await asyncio.create_subprocess_exec(  # nosec B603 - argv is an internally-built list; exec form takes no shell
                     *cmd,
                     stdin=asyncio.subprocess.PIPE if input_text is not None else None,
@@ -669,6 +682,7 @@ class CliTransport(ABC):
                     stderr=asyncio.subprocess.PIPE,
                     env=env,
                     cwd=cwd,
+                    **spawn_kwargs,
                 )
             except FileNotFoundError as exc:
                 raise AINotAvailableError(

--- a/lintro/ai/review/interrupt.py
+++ b/lintro/ai/review/interrupt.py
@@ -1,0 +1,71 @@
+"""SIGTERM/SIGINT handling so a killed review can persist coverage (#2156).
+
+GitHub Actions sends SIGTERM to the review step process group (~5–7 s
+before SIGKILL). The Cursor ``agent`` CLI has also been observed to
+``killpg`` its own group, which would take lintro with it unless the
+child is started in a new session. This module turns the first signal
+into a cooperative stop so the orchestrator can write ``state.json``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import signal
+from collections.abc import Callable
+from contextlib import suppress
+
+from loguru import logger
+
+from lintro.ai.exceptions import AIProviderError
+
+SIGTERM_TIMEOUT_MESSAGE = "review timed out after SIGTERM"
+
+
+def sigterm_timeout_error() -> AIProviderError:
+    """Return the persistable timeout error used for a review interrupt.
+
+    Returns:
+        An ``AIProviderError`` classified as ``TIMEOUT`` (``timed out``)
+        and chained from ``TimeoutError`` so the existing mid-round
+        persist path treats it like a CLI timeout.
+    """
+    error = AIProviderError(SIGTERM_TIMEOUT_MESSAGE)
+    error.__cause__ = TimeoutError("SIGTERM")
+    return error
+
+
+def install_review_interrupt(stop: asyncio.Event) -> Callable[[], None]:
+    """Request *stop* when the process receives SIGTERM or SIGINT.
+
+    Args:
+        stop: Event set by the first signal. The orchestrator waits on
+            this and then persists completed chunks.
+
+    Returns:
+        A callable that removes the handlers. Safe to call more than once.
+    """
+    loop = asyncio.get_running_loop()
+    installed: list[signal.Signals] = []
+
+    def _request_stop() -> None:
+        """Set the stop event once and log that persist should follow."""
+        if stop.is_set():
+            return
+        logger.warning(
+            "Review received SIGTERM/SIGINT; persisting coverage and stopping",
+        )
+        stop.set()
+
+    for sig in (signal.SIGTERM, signal.SIGINT):
+        with suppress(NotImplementedError, RuntimeError, ValueError):
+            loop.add_signal_handler(sig, _request_stop)
+            installed.append(sig)
+
+    def _uninstall() -> None:
+        """Remove handlers installed by this call."""
+        for sig in installed:
+            with suppress(NotImplementedError, RuntimeError, ValueError):
+                loop.remove_signal_handler(sig)
+        installed.clear()
+
+    return _uninstall

--- a/lintro/ai/review/orchestrator.py
+++ b/lintro/ai/review/orchestrator.py
@@ -20,6 +20,7 @@ from lintro.ai.enums import AITransport
 from lintro.ai.exceptions import (
     AICostBudgetExceededError,
     AIError,
+    AIProviderError,
 )
 from lintro.ai.invoke import call_ai
 from lintro.ai.json_response import parse_review_response_payload, strip_json_fences
@@ -84,6 +85,7 @@ from lintro.ai.review.finding_parser import (
 )
 from lintro.ai.review.group_labels import REL_DIRECTORY_PREFIX, REL_SINGLE_FILE
 from lintro.ai.review.interrupt import (
+    SIGTERM_TIMEOUT_MESSAGE,
     install_review_interrupt,
     sigterm_timeout_error,
 )
@@ -515,7 +517,9 @@ async def _review_one_chunk_until_stop(
             review_task.cancel()
             with suppress(asyncio.CancelledError):
                 await review_task
-            raise sigterm_timeout_error()
+            raise AIProviderError(SIGTERM_TIMEOUT_MESSAGE) from TimeoutError(
+                "SIGTERM",
+            )
         return await review_task
     finally:
         if not stop_task.done():

--- a/lintro/ai/review/orchestrator.py
+++ b/lintro/ai/review/orchestrator.py
@@ -83,6 +83,10 @@ from lintro.ai.review.finding_parser import (
     reject_context_findings,
 )
 from lintro.ai.review.group_labels import REL_DIRECTORY_PREFIX, REL_SINGLE_FILE
+from lintro.ai.review.interrupt import (
+    install_review_interrupt,
+    sigterm_timeout_error,
+)
 from lintro.ai.review.models.checklist_answer import ChecklistAnswer
 from lintro.ai.review.models.coverage_counts import CoverageCounts
 from lintro.ai.review.models.file_assessment import FileAssessment
@@ -430,6 +434,96 @@ def resolve_review_chunks(
     return chunking.chunks
 
 
+async def _review_one_chunk_until_stop(
+    *,
+    chunk: ReviewChunk,
+    context: ReviewContext,
+    provider: BaseAIProvider,
+    ai_config: AIConfig,
+    depth: int,
+    checklist_items: list[ChecklistItem],
+    checklist_text: str,
+    classifications: list[FileClassification],
+    lint_results: str | None,
+    budget: CostBudget,
+    progress: ReviewProgressCallback,
+    repo_root: str,
+    use_one_shot: bool,
+    strictness_section: str,
+    next_generated_checklist_id: int,
+    diff_budget: int,
+    stop: asyncio.Event | None,
+) -> _ChunkReviewPartial:
+    """Review a single chunk, aborting persistably when *stop* is set.
+
+    Args:
+        chunk: The only remaining chunk.
+        context: Review diff context.
+        provider: Configured AI provider.
+        ai_config: Effective AI configuration.
+        depth: Review depth.
+        checklist_items: Selected checklist items.
+        checklist_text: Pre-formatted checklist prompt.
+        classifications: Domain classifications.
+        lint_results: Optional lint digest.
+        budget: Run cost budget.
+        progress: Progress callback.
+        repo_root: Workspace root for the provider.
+        use_one_shot: Whether to avoid a durable CLI session.
+        strictness_section: Strictness prompt fragment.
+        next_generated_checklist_id: Next generated checklist id.
+        diff_budget: Token budget for the diff.
+        stop: Optional SIGTERM event.
+
+    Returns:
+        The completed chunk partial.
+
+    Raises:
+        AIProviderError: When SIGTERM arrives before the chunk finishes.
+    """
+    review_task = asyncio.ensure_future(
+        _review_chunk_with_progress(
+            chunk_index=0,
+            chunk=chunk,
+            context=context,
+            provider=provider,
+            ai_config=ai_config,
+            depth=depth,
+            checklist_text=checklist_text,
+            checklist_count=len(checklist_items),
+            classifications=classifications,
+            lint_results=lint_results,
+            budget=budget,
+            progress=progress,
+            total_chunks=1,
+            repo_root=repo_root,
+            use_one_shot=use_one_shot,
+            strictness_section=strictness_section,
+            next_generated_checklist_id=next_generated_checklist_id,
+            diff_budget=diff_budget,
+        ),
+    )
+    if stop is None:
+        return await review_task
+    stop_task = asyncio.ensure_future(stop.wait())
+    try:
+        done, _pending = await asyncio.wait(
+            {review_task, stop_task},
+            return_when=asyncio.FIRST_COMPLETED,
+        )
+        if stop_task in done and stop.is_set() and not review_task.done():
+            review_task.cancel()
+            with suppress(asyncio.CancelledError):
+                await review_task
+            raise sigterm_timeout_error()
+        return await review_task
+    finally:
+        if not stop_task.done():
+            stop_task.cancel()
+            with suppress(asyncio.CancelledError):
+                await stop_task
+
+
 async def _review_all_chunks(
     *,
     chunks: list[ReviewChunk],
@@ -451,6 +545,7 @@ async def _review_all_chunks(
     diff_budget: int,
     completed_sink: list[_ChunkReviewPartial] | None = None,
     on_chunk_complete: Callable[[list[_ChunkReviewPartial]], None] | None = None,
+    stop: asyncio.Event | None = None,
 ) -> list[_ChunkReviewPartial]:
     """Review all chunks with bounded concurrency.
 
@@ -467,27 +562,28 @@ async def _review_all_chunks(
     cost-cap stop cancels the remaining work and propagates to
     ``run_review_async``. Depth ≥ 2 assigns each chunk a disjoint
     generated-checklist id range so merge stays deterministic under fan-out.
+    ``stop`` is set by a SIGTERM/SIGINT handler so an in-flight chunk can
+    be cancelled and completed siblings persisted (#2156).
     """
     if len(chunks) <= 1:
-        single = await _review_chunk_with_progress(
-            chunk_index=0,
+        single = await _review_one_chunk_until_stop(
             chunk=chunks[0],
             context=context,
             provider=provider,
             ai_config=ai_config,
             depth=depth,
+            checklist_items=checklist_items,
             checklist_text=checklist_text,
-            checklist_count=len(checklist_items),
             classifications=classifications,
             lint_results=lint_results,
             budget=budget,
             progress=progress,
-            total_chunks=1,
             repo_root=repo_root,
             use_one_shot=use_one_shot,
             strictness_section=strictness_section,
             next_generated_checklist_id=next_generated_checklist_id,
             diff_budget=diff_budget,
+            stop=stop,
         )
         if completed_sink is not None:
             completed_sink.append(single)
@@ -549,17 +645,40 @@ async def _review_all_chunks(
             except Exception as exc:
                 return chunk_index, exc
 
-    tasks = [
+    review_tasks = [
         asyncio.ensure_future(_run_chunk(chunk_index, chunk))
         for chunk_index, chunk in enumerate(chunks)
     ]
+    stop_task: asyncio.Future[tuple[int, _ChunkReviewPartial | Exception]] | None
+    stop_task = None
+    if stop is not None:
+        interrupt = stop
+
+        async def _stop_as_timeout() -> tuple[int, _ChunkReviewPartial | Exception]:
+            """Surface SIGTERM as a persistable timeout outcome."""
+            await interrupt.wait()
+            return -1, sigterm_timeout_error()
+
+        stop_task = asyncio.ensure_future(_stop_as_timeout())
+    tasks: list[asyncio.Future[tuple[int, _ChunkReviewPartial | Exception]]] = [
+        *review_tasks,
+    ]
+    if stop_task is not None:
+        tasks.append(stop_task)
 
     completed = 0
+    remaining_reviews = len(review_tasks)
     try:
         for finished in asyncio.as_completed(tasks):
             chunk_index, outcome = await finished
-            if isinstance(outcome, (ReviewExecutionError, AICostBudgetExceededError)):
-                # A cost-cap / timeout stop is an expected graceful halt.
+            if chunk_index >= 0:
+                remaining_reviews -= 1
+            graceful_stop = isinstance(
+                outcome,
+                (ReviewExecutionError, AICostBudgetExceededError),
+            ) or (isinstance(outcome, Exception) and _is_timeout_stop(exc=outcome))
+            if graceful_stop:
+                # A cost-cap / timeout / SIGTERM stop is an expected halt.
                 # Harvest siblings that already finished so a timeout on
                 # one worker cannot drop coverage the other worker wrote.
                 for task in tasks:
@@ -582,7 +701,8 @@ async def _review_all_chunks(
                         completed_sink.append(other)
                         if on_chunk_complete is not None:
                             on_chunk_complete(completed_sink)
-                raise outcome
+                if isinstance(outcome, Exception):
+                    raise outcome
             if isinstance(outcome, Exception):
                 if first_error is None:
                     first_error = _aborted_before_completion(
@@ -600,6 +720,8 @@ async def _review_all_chunks(
                 if on_chunk_complete is not None:
                     on_chunk_complete(completed_sink)
             completed += 1
+            if remaining_reviews == 0:
+                break
     finally:
         for task in tasks:
             if not task.done():
@@ -711,6 +833,7 @@ def run_review(
     prior_state: ReviewState | None = None,
     force_full: bool = False,
     enforce_cost_cap: bool = True,
+    stop: asyncio.Event | None = None,
 ) -> ReviewResult:
     """Execute an AI diff review from synchronous code.
 
@@ -744,6 +867,7 @@ def run_review(
         force_full: Discard carried coverage (``--full``).
         enforce_cost_cap: When True, honor ``ai.max_cost_usd`` and serialize
             chunk calls so concurrency cannot violate queue order.
+        stop: Optional event set to persist and halt (tests inject this).
 
     Returns:
         Complete review result with metadata, checklist, and findings.
@@ -770,6 +894,7 @@ def run_review(
             prior_state=prior_state,
             force_full=force_full,
             enforce_cost_cap=enforce_cost_cap,
+            stop=stop,
         ),
     )
 
@@ -796,6 +921,7 @@ async def run_review_async(
     prior_state: ReviewState | None = None,
     force_full: bool = False,
     enforce_cost_cap: bool = True,
+    stop: asyncio.Event | None = None,
 ) -> ReviewResult:
     """Execute an AI diff review with depth-controlled passes.
 
@@ -826,6 +952,8 @@ async def run_review_async(
         force_full: Discard carried coverage (``--full``).
         enforce_cost_cap: When True, honor ``ai.max_cost_usd`` and serialize
             chunk calls so concurrency cannot violate queue order.
+        stop: Optional event set to persist and halt (tests inject this;
+            production uses SIGTERM/SIGINT via :func:`install_review_interrupt`).
 
     Returns:
         Complete review result with metadata, checklist, and findings.
@@ -952,6 +1080,8 @@ async def run_review_async(
     provider_started = started_at
     provider_seconds = 0.0
     parse_merge_seconds = 0.0
+    interrupt = stop if stop is not None else asyncio.Event()
+    uninstall_interrupt = install_review_interrupt(interrupt)
     try:
         # Open the session inside the try so a failure before or during
         # on_start() still reaches the finally that tears it down.
@@ -1011,6 +1141,7 @@ async def run_review_async(
                 diff_budget=diff_budget,
                 completed_sink=collected,
                 on_chunk_complete=_checkpoint,
+                stop=interrupt,
             )
         if resume.queue:
             await run_custom_agent_passes(
@@ -1095,6 +1226,7 @@ async def run_review_async(
             cause=str(exc),
         )
     finally:
+        uninstall_interrupt()
         if durable_session_started:
             provider.end_durable_session()
         with suppress(Exception):

--- a/lintro/ai/review/orchestrator.py
+++ b/lintro/ai/review/orchestrator.py
@@ -701,7 +701,7 @@ async def _review_all_chunks(
                         completed_sink.append(other)
                         if on_chunk_complete is not None:
                             on_chunk_complete(completed_sink)
-                if isinstance(outcome, Exception):
+                if isinstance(outcome, (AIError, ReviewExecutionError)):
                     raise outcome
             if isinstance(outcome, Exception):
                 if first_error is None:
@@ -1208,7 +1208,12 @@ async def run_review_async(
         total_findings = len(filtered_findings)
         parse_merge_seconds = time.monotonic() - merge_started
         completed = True
-        if stopped_reason.startswith("timeout"):
+        if "SIGTERM" in stopped_reason:
+            hint = (
+                "The runner sent SIGTERM; coverage was persisted. "
+                "Re-run to resume remaining files."
+            )
+        elif stopped_reason.startswith("timeout"):
             timeout_setting = (
                 "ai.transports.cli.timeout"
                 if ai_config.transport is AITransport.CLI

--- a/lintro/ai/review/orchestrator.py
+++ b/lintro/ai/review/orchestrator.py
@@ -513,13 +513,22 @@ async def _review_one_chunk_until_stop(
             {review_task, stop_task},
             return_when=asyncio.FIRST_COMPLETED,
         )
-        if stop_task in done and stop.is_set() and not review_task.done():
-            review_task.cancel()
-            with suppress(asyncio.CancelledError):
-                await review_task
-            raise AIProviderError(SIGTERM_TIMEOUT_MESSAGE) from TimeoutError(
-                "SIGTERM",
-            )
+        if stop_task in done and stop.is_set():
+            if not review_task.done():
+                review_task.cancel()
+                with suppress(asyncio.CancelledError):
+                    await review_task
+                raise AIProviderError(SIGTERM_TIMEOUT_MESSAGE) from TimeoutError(
+                    "SIGTERM",
+                )
+            # The agent may have died from a forwarded TERM before the
+            # stop task won. Treat that failure as the persistable
+            # SIGTERM timeout instead of aborting without coverage.
+            if review_task.cancelled() or review_task.exception() is not None:
+                raise AIProviderError(SIGTERM_TIMEOUT_MESSAGE) from TimeoutError(
+                    "SIGTERM",
+                )
+            return review_task.result()
         return await review_task
     finally:
         if not stop_task.done():
@@ -677,6 +686,15 @@ async def _review_all_chunks(
             chunk_index, outcome = await finished
             if chunk_index >= 0:
                 remaining_reviews -= 1
+            if (
+                isinstance(outcome, Exception)
+                and stop is not None
+                and stop.is_set()
+                and not _is_cost_cap_stop(exc=outcome)
+            ):
+                # A forwarded TERM can kill the isolated agent and surface
+                # a non-timeout provider error. Persist as SIGTERM anyway.
+                outcome = sigterm_timeout_error()
             graceful_stop = isinstance(
                 outcome,
                 (ReviewExecutionError, AICostBudgetExceededError),

--- a/lintro/cli_utils/commands/review.py
+++ b/lintro/cli_utils/commands/review.py
@@ -100,6 +100,7 @@ from lintro.utils.execution.advisory import (
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
+    from lintro.ai.review.models.review_result import ReviewResult
     from lintro.models.core.tool_result import ToolResult
 
 #: Default paths scanned by ``--advisory-only`` when no ``--path`` is given.
@@ -718,15 +719,23 @@ def review_command(
 
     result = enrich_review_result(result=result, question_map=question_map)
 
-    advisory_results = _execute_advisory(
-        advisory_tools=advisory_tools,
-        tool_options=tool_options,
-        paths=_existing_changed_files(
-            changed_files=context.changed_files,
-            workspace_root=workspace_root,
-        ),
-        ai_config=effective_ai_config,
-    )
+    skip_post_tail = _skip_sigterm_post_tail(result=result)
+    if skip_post_tail:
+        logger.warning(
+            "Skipping advisory tools and --post after SIGTERM so the "
+            "wrapper can classify the envelope before the runner SIGKILL",
+        )
+        advisory_results = []
+    else:
+        advisory_results = _execute_advisory(
+            advisory_tools=advisory_tools,
+            tool_options=tool_options,
+            paths=_existing_changed_files(
+                changed_files=context.changed_files,
+                workspace_root=workspace_root,
+            ),
+            ai_config=effective_ai_config,
+        )
 
     output = render_review_output(
         result=result,
@@ -746,7 +755,7 @@ def review_command(
         if advisory_text:
             click.echo(f"\n{advisory_text}")
 
-    if post:
+    if post and not skip_post_tail:
         from lintro.ai.review.github import post_review_to_github
 
         captured_comment_ids: dict[str, int] = {}
@@ -921,6 +930,25 @@ def _existing_changed_files(
         if candidate.is_file():
             paths.append(str(candidate))
     return paths
+
+
+def _skip_sigterm_post_tail(*, result: ReviewResult) -> bool:
+    """Return True when runner SIGTERM left only the persist window.
+
+    GitHub Actions SIGKILLs the review step ~5–7s after SIGTERM. Coverage
+    is already on disk (incremental parts plus the final persist above).
+    Advisory tools and ``--post`` can burn that window so the wrapper
+    never classifies the JSON envelope and ``if: always()`` upload is
+    skipped. The next resume run posts the sticky and inlines.
+
+    Args:
+        result: Completed or partial review result.
+
+    Returns:
+        True when this run is a SIGTERM partial and must exit immediately
+        after writing the envelope.
+    """
+    return result.metadata.partial and "SIGTERM" in result.metadata.stopped_reason
 
 
 def _execute_advisory(

--- a/scripts/ci/run-ai-review.sh
+++ b/scripts/ci/run-ai-review.sh
@@ -136,6 +136,16 @@ if [[ -z "$pr_number" ]]; then
 fi
 
 echo "Running AI review on PR #${pr_number} (posts comment)..."
+# Heartbeat so a silent ``--output json`` review still proves the step is
+# alive if the runner SIGTERM's it. Killed on EXIT with the output file.
+(
+	elapsed=0
+	while sleep 60; do
+		elapsed=$((elapsed + 60))
+		printf '[ai-review] still running (%ss)\n' "${elapsed}"
+	done
+) &
+heartbeat_pid=$!
 
 # `--post` maintains the sticky review comment (and inline findings) on the PR.
 # It needs GITHUB_TOKEN (write) and the repo; the diff is still fetched via `gh`.
@@ -152,7 +162,11 @@ mkdir -p "${LINTRO_REVIEW_STATE_DIR}"
 # Tee to a file: the classifier needs the JSON error envelope, and the live
 # stream must still reach the Actions log so a mid-run SIGTERM is diagnosable.
 output_file="$(mktemp)"
-trap 'rm -f "$output_file"' EXIT
+trap 'rm -f "$output_file"; kill "${heartbeat_pid:-}" 2>/dev/null || true' EXIT
+# Stay alive on SIGTERM long enough for lintro's handler to persist
+# coverage. The runner signals the process group, so Python still sees it.
+# A no-op trap keeps this shell from exiting before the classifier runs.
+trap ':' TERM
 
 set +e
 # Timeout comes from ai.transports.cli.timeout (default 1800s) — no hand-tuned
@@ -173,6 +187,7 @@ set +e
 # lintro.ai.transport.DEFAULT_CLI_TIMEOUT.
 # shellcheck disable=SC2034  # documentation variable read by the wiring test
 CLI_REVIEW_TIMEOUT_SECONDS=1800
+echo "CLI timeout ${CLI_REVIEW_TIMEOUT_SECONDS}s; persist-on-SIGTERM enabled."
 # Unbuffered Python so the tee pipeline shows mid-chunk progress if SIGTERM'd.
 export PYTHONUNBUFFERED=1
 uv run lintro review --pr "${pr_number}" "${repo_arg[@]}" --depth 1 --post --output json 2>&1 | tee "$output_file"

--- a/scripts/ci/run-ai-review.sh
+++ b/scripts/ci/run-ai-review.sh
@@ -219,6 +219,19 @@ while kill -0 "$lintro_pid" 2>/dev/null; do
 	wait "$lintro_pid"
 	review_status=$?
 done
+# If wait returned 143 after lintro already exited, recover the real status.
+if ! kill -0 "$lintro_pid" 2>/dev/null; then
+	wait "$lintro_pid" 2>/dev/null
+	reaped=$?
+	if [[ "$reaped" -ne 127 ]]; then
+		review_status=$reaped
+	fi
+fi
+# Let GNU tail --pid flush the envelope, then SIGKILL the TERM-immune mirror.
+for _ in 1 2 3 4; do
+	kill -0 "${log_pid:-}" 2>/dev/null || break
+	sleep 0.5
+done
 kill -KILL "${log_pid:-}" 2>/dev/null || true
 wait "${log_pid:-}" 2>/dev/null || true
 trap - TERM INT

--- a/scripts/ci/run-ai-review.sh
+++ b/scripts/ci/run-ai-review.sh
@@ -210,7 +210,10 @@ uv run lintro review --pr "${pr_number}" "${repo_arg[@]}" --depth 1 --post --out
 lintro_pid=$!
 # --pid makes tail exit when lintro is gone. SIGKILL reaps it if a
 # group signal left it ignoring TERM (``trap '' TERM``).
-(trap '' TERM; tail --pid="$lintro_pid" -n +1 -f "$output_file") &
+(
+	trap '' TERM
+	tail --pid="$lintro_pid" -n +1 -f "$output_file"
+) &
 log_pid=$!
 wait "$lintro_pid"
 review_status=$?

--- a/scripts/ci/run-ai-review.sh
+++ b/scripts/ci/run-ai-review.sh
@@ -166,8 +166,8 @@ log_pid=""
 lintro_pid=""
 _cleanup_review() {
 	rm -f "$output_file"
-	kill "${heartbeat_pid:-}" 2>/dev/null || true
-	kill "${log_pid:-}" 2>/dev/null || true
+	kill -KILL "${heartbeat_pid:-}" 2>/dev/null || true
+	kill -KILL "${log_pid:-}" 2>/dev/null || true
 }
 trap '_cleanup_review' EXIT
 # Forward SIGTERM to lintro (runner may signal only this shell) and keep
@@ -175,6 +175,10 @@ trap '_cleanup_review' EXIT
 _forward_term() {
 	if [[ -n "${lintro_pid:-}" ]]; then
 		kill -TERM "$lintro_pid" 2>/dev/null || true
+		# uv run may wrap Python; signal children if uv did not exec.
+		while read -r child; do
+			kill -TERM "$child" 2>/dev/null || true
+		done < <(pgrep -P "$lintro_pid" || true)
 	fi
 }
 trap '_forward_term' TERM INT
@@ -204,11 +208,18 @@ echo "CLI timeout ${CLI_REVIEW_TIMEOUT_SECONDS}s; persist-on-SIGTERM enabled."
 export PYTHONUNBUFFERED=1
 uv run lintro review --pr "${pr_number}" "${repo_arg[@]}" --depth 1 --post --output json >"$output_file" 2>&1 &
 lintro_pid=$!
-(trap '' TERM; tail -n +1 -f "$output_file") &
+# --pid makes tail exit when lintro is gone. SIGKILL reaps it if a
+# group signal left it ignoring TERM (``trap '' TERM``).
+(trap '' TERM; tail --pid="$lintro_pid" -n +1 -f "$output_file") &
 log_pid=$!
 wait "$lintro_pid"
 review_status=$?
-kill "${log_pid:-}" 2>/dev/null || true
+# A trap can interrupt wait while lintro is still persisting. Reap it.
+while kill -0 "$lintro_pid" 2>/dev/null; do
+	wait "$lintro_pid"
+	review_status=$?
+done
+kill -KILL "${log_pid:-}" 2>/dev/null || true
 wait "${log_pid:-}" 2>/dev/null || true
 trap - TERM INT
 set -e

--- a/scripts/ci/run-ai-review.sh
+++ b/scripts/ci/run-ai-review.sh
@@ -175,8 +175,16 @@ trap '_cleanup_review' EXIT
 _forward_term() {
 	if [[ -n "${lintro_pid:-}" ]]; then
 		kill -TERM "$lintro_pid" 2>/dev/null || true
-		# uv run may wrap Python; signal children if uv did not exec.
+		# uv run may wrap Python; signal non-session-leader children if uv
+		# did not exec. Skip session leaders — that is the isolated agent
+		# CLI (start_new_session). The orchestrator killpg's it on cancel.
+		# TERMing the agent here can surface a non-timeout provider error
+		# that aborts INCOMPLETE persist.
 		while read -r child; do
+			sid=$(ps -o sid= -p "$child" 2>/dev/null | tr -d ' ')
+			if [[ -n "$sid" && "$sid" == "$child" ]]; then
+				continue
+			fi
 			kill -TERM "$child" 2>/dev/null || true
 		done < <(pgrep -P "$lintro_pid" || true)
 	fi

--- a/scripts/ci/run-ai-review.sh
+++ b/scripts/ci/run-ai-review.sh
@@ -137,11 +137,11 @@ fi
 
 echo "Running AI review on PR #${pr_number} (posts comment)..."
 # Heartbeat so a silent ``--output json`` review still proves the step is
-# alive if the runner SIGTERM's it. Killed on EXIT with the output file.
+# alive if the runner SIGTERM's it. Short sleeps so EXIT can reap quickly.
 (
 	elapsed=0
-	while sleep 60; do
-		elapsed=$((elapsed + 60))
+	while sleep 15; do
+		elapsed=$((elapsed + 15))
 		printf '[ai-review] still running (%ss)\n' "${elapsed}"
 	done
 ) &
@@ -162,11 +162,22 @@ mkdir -p "${LINTRO_REVIEW_STATE_DIR}"
 # Tee to a file: the classifier needs the JSON error envelope, and the live
 # stream must still reach the Actions log so a mid-run SIGTERM is diagnosable.
 output_file="$(mktemp)"
-trap 'rm -f "$output_file"; kill "${heartbeat_pid:-}" 2>/dev/null || true' EXIT
-# Stay alive on SIGTERM long enough for lintro's handler to persist
-# coverage. The runner signals the process group, so Python still sees it.
-# A no-op trap keeps this shell from exiting before the classifier runs.
-trap ':' TERM
+log_pid=""
+lintro_pid=""
+_cleanup_review() {
+	rm -f "$output_file"
+	kill "${heartbeat_pid:-}" 2>/dev/null || true
+	kill "${log_pid:-}" 2>/dev/null || true
+}
+trap '_cleanup_review' EXIT
+# Forward SIGTERM to lintro (runner may signal only this shell) and keep
+# the log mirror alive so the JSON envelope still reaches $output_file.
+_forward_term() {
+	if [[ -n "${lintro_pid:-}" ]]; then
+		kill -TERM "$lintro_pid" 2>/dev/null || true
+	fi
+}
+trap '_forward_term' TERM INT
 
 set +e
 # Timeout comes from ai.transports.cli.timeout (default 1800s) — no hand-tuned
@@ -188,10 +199,18 @@ set +e
 # shellcheck disable=SC2034  # documentation variable read by the wiring test
 CLI_REVIEW_TIMEOUT_SECONDS=1800
 echo "CLI timeout ${CLI_REVIEW_TIMEOUT_SECONDS}s; persist-on-SIGTERM enabled."
-# Unbuffered Python so the tee pipeline shows mid-chunk progress if SIGTERM'd.
+# Unbuffered Python. Write the envelope to a file (not a SIGTERM-fragile
+# ``| tee`` pipe) and mirror it to the Actions log with a TERM-immune tail.
 export PYTHONUNBUFFERED=1
-uv run lintro review --pr "${pr_number}" "${repo_arg[@]}" --depth 1 --post --output json 2>&1 | tee "$output_file"
+uv run lintro review --pr "${pr_number}" "${repo_arg[@]}" --depth 1 --post --output json >"$output_file" 2>&1 &
+lintro_pid=$!
+(trap '' TERM; tail -n +1 -f "$output_file") &
+log_pid=$!
+wait "$lintro_pid"
 review_status=$?
+kill "${log_pid:-}" 2>/dev/null || true
+wait "${log_pid:-}" 2>/dev/null || true
+trap - TERM INT
 set -e
 
 # Exits 0 only when a review was produced; the classifier writes the annotation

--- a/tests/scripts/test_run_ai_review.py
+++ b/tests/scripts/test_run_ai_review.py
@@ -1005,8 +1005,9 @@ def test_run_ai_review_tees_under_pipefail() -> None:
     shell_text = SHELL_SCRIPT.read_text(encoding="utf-8")
     assert_that(shell_text).contains("set -euo pipefail")
     assert_that(shell_text).contains("PYTHONUNBUFFERED=1")
-    assert_that(shell_text).contains('| tee "$output_file"')
-    assert_that(shell_text).contains("trap ':' TERM")
+    assert_that(shell_text).contains('>"$output_file" 2>&1 &')
+    assert_that(shell_text).contains('kill -TERM "$lintro_pid"')
+    assert_that(shell_text).contains("trap '' TERM")
     assert_that(shell_text).contains("[ai-review] still running")
     assert_that(shell_text).contains("persist-on-SIGTERM enabled")
     result = subprocess.run(  # nosec B603 B607 - fixed bash argv in a controlled test; binary name resolved from PATH, not attacker-controlled; shell=False

--- a/tests/scripts/test_run_ai_review.py
+++ b/tests/scripts/test_run_ai_review.py
@@ -1007,6 +1007,8 @@ def test_run_ai_review_tees_under_pipefail() -> None:
     assert_that(shell_text).contains("PYTHONUNBUFFERED=1")
     assert_that(shell_text).contains('>"$output_file" 2>&1 &')
     assert_that(shell_text).contains('kill -TERM "$lintro_pid"')
+    assert_that(shell_text).contains('tail --pid="$lintro_pid"')
+    assert_that(shell_text).contains("kill -KILL")
     assert_that(shell_text).contains("trap '' TERM")
     assert_that(shell_text).contains("[ai-review] still running")
     assert_that(shell_text).contains("persist-on-SIGTERM enabled")
@@ -1021,6 +1023,40 @@ def test_run_ai_review_tees_under_pipefail() -> None:
         text=True,
     )
     assert_that(result.returncode).is_not_equal_to(0)
+
+
+def test_term_immune_log_mirror_is_reaped_with_sigkill() -> None:
+    """A ``trap '' TERM`` tail must not block wait after the review exits."""
+    result = subprocess.run(  # nosec B603 B607 - fixed bash argv in a controlled test; binary name resolved from PATH, not attacker-controlled; shell=False
+        [
+            "bash",
+            "-c",
+            """
+            set -euo pipefail
+            tmp="$(mktemp)"
+            : >"$tmp"
+            ( sleep 0.2; printf '{}\\n' >"$tmp" ) &
+            child=$!
+            (trap '' TERM; tail --pid="$child" -n +1 -f "$tmp") &
+            log_pid=$!
+            wait "$child"
+            status=$?
+            while kill -0 "$child" 2>/dev/null; do
+              wait "$child"
+              status=$?
+            done
+            kill -KILL "$log_pid" 2>/dev/null || true
+            wait "$log_pid" 2>/dev/null || true
+            rm -f "$tmp"
+            exit "$status"
+            """,
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=5,
+    )
+    assert_that(result.returncode).is_equal_to(0)
 
 
 def test_review_timeout_fits_inside_the_job_timeout() -> None:

--- a/tests/scripts/test_run_ai_review.py
+++ b/tests/scripts/test_run_ai_review.py
@@ -1010,6 +1010,8 @@ def test_run_ai_review_tees_under_pipefail() -> None:
     assert_that(shell_text).contains('tail --pid="$lintro_pid"')
     assert_that(shell_text).contains("kill -KILL")
     assert_that(shell_text).contains("trap '' TERM")
+    assert_that(shell_text).contains("reaped=$?")
+    assert_that(shell_text).contains("sleep 0.5")
     assert_that(shell_text).contains("[ai-review] still running")
     assert_that(shell_text).contains("persist-on-SIGTERM enabled")
     result = subprocess.run(  # nosec B603 B607 - fixed bash argv in a controlled test; binary name resolved from PATH, not attacker-controlled; shell=False

--- a/tests/scripts/test_run_ai_review.py
+++ b/tests/scripts/test_run_ai_review.py
@@ -1008,6 +1008,8 @@ def test_run_ai_review_tees_under_pipefail() -> None:
     assert_that(shell_text).contains('>"$output_file" 2>&1 &')
     assert_that(shell_text).contains('kill -TERM "$lintro_pid"')
     assert_that(shell_text).contains('tail --pid="$lintro_pid"')
+    assert_that(shell_text).contains('ps -o sid=')
+    assert_that(shell_text).contains('"$sid" == "$child"')
     assert_that(shell_text).contains("kill -KILL")
     assert_that(shell_text).contains("trap '' TERM")
     assert_that(shell_text).contains("reaped=$?")

--- a/tests/scripts/test_run_ai_review.py
+++ b/tests/scripts/test_run_ai_review.py
@@ -1008,7 +1008,7 @@ def test_run_ai_review_tees_under_pipefail() -> None:
     assert_that(shell_text).contains('>"$output_file" 2>&1 &')
     assert_that(shell_text).contains('kill -TERM "$lintro_pid"')
     assert_that(shell_text).contains('tail --pid="$lintro_pid"')
-    assert_that(shell_text).contains('ps -o sid=')
+    assert_that(shell_text).contains("ps -o sid=")
     assert_that(shell_text).contains('"$sid" == "$child"')
     assert_that(shell_text).contains("kill -KILL")
     assert_that(shell_text).contains("trap '' TERM")

--- a/tests/scripts/test_run_ai_review.py
+++ b/tests/scripts/test_run_ai_review.py
@@ -1006,6 +1006,9 @@ def test_run_ai_review_tees_under_pipefail() -> None:
     assert_that(shell_text).contains("set -euo pipefail")
     assert_that(shell_text).contains("PYTHONUNBUFFERED=1")
     assert_that(shell_text).contains('| tee "$output_file"')
+    assert_that(shell_text).contains("trap ':' TERM")
+    assert_that(shell_text).contains("[ai-review] still running")
+    assert_that(shell_text).contains("persist-on-SIGTERM enabled")
     result = subprocess.run(  # nosec B603 B607 - fixed bash argv in a controlled test; binary name resolved from PATH, not attacker-controlled; shell=False
         [
             "bash",

--- a/tests/unit/ai/providers/test_cli_capability_guard.py
+++ b/tests/unit/ai/providers/test_cli_capability_guard.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import asyncio
+import os
 import subprocess  # nosec B404 - CompletedProcess objects are constructed to drive the transport under test
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from assertpy import assert_that
@@ -500,6 +502,26 @@ async def test_run_guarded_matches_flag_on_token_boundary(
 
 
 # -- Subprocess execution ---------------------------------------------------
+
+
+async def test_run_starts_child_in_new_session(transport: _FakeTransport) -> None:
+    """Agent children must not share lintro's process group (#2156)."""
+    process = MagicMock()
+    process.communicate = AsyncMock(return_value=(b'{"ok": true}', b""))
+    process.returncode = 0
+    process.pid = 4242
+
+    with patch(
+        "asyncio.create_subprocess_exec",
+        AsyncMock(return_value=process),
+    ) as spawn:
+        await transport.run(["/usr/local/bin/fake", "--always"], timeout=5.0)
+
+    kwargs = spawn.call_args.kwargs
+    if os.name == "posix":
+        assert_that(kwargs.get("start_new_session")).is_true()
+    else:
+        assert_that(kwargs).does_not_contain_key("start_new_session")
 
 
 async def test_run_raises_provider_error_on_timeout(transport: _FakeTransport) -> None:

--- a/tests/unit/ai/review/test_orchestrator.py
+++ b/tests/unit/ai/review/test_orchestrator.py
@@ -382,6 +382,75 @@ async def test_run_review_returns_partial_on_sigterm() -> None:
     assert_that({record.path for record in result.coverage_records}).contains("a.py")
 
 
+async def test_run_review_persists_when_agent_dies_after_sigterm() -> None:
+    """A non-timeout agent death after stop still persists completed chunks."""
+    provider = _mock_provider(content=_sample_response_json(finding_file="a.py"))
+    chunks = [
+        ReviewChunk(
+            id=1,
+            files=["a.py"],
+            diff="diff --git a/a.py b/a.py\n+x",
+            relationship=REL_SINGLE_FILE,
+        ),
+        ReviewChunk(
+            id=2,
+            files=["b.py"],
+            diff="diff --git a/b.py b/b.py\n+y",
+            relationship=REL_SINGLE_FILE,
+        ),
+    ]
+    seen: list[str] = []
+    stop = asyncio.Event()
+
+    async def _die_after_stop(
+        *,
+        provider,
+        user_prompt,
+        budget=None,
+        **kwargs,
+    ):  # noqa: ANN001, ANN003, ANN202
+        del budget
+        seen.append("call")
+        if len(seen) >= 2:
+            stop.set()
+            raise AIProviderError("agent exited 143")
+        return provider.complete(
+            user_prompt,
+            system=kwargs.get("system_prompt"),
+            max_tokens=kwargs.get("max_tokens", 1024),
+        )
+
+    with (
+        patch(
+            "lintro.ai.review.orchestrator.resolve_review_chunks",
+            return_value=chunks,
+        ),
+        patch(
+            "lintro.ai.review.orchestrator.call_ai",
+            side_effect=_die_after_stop,
+        ),
+    ):
+        result = await run_review_async(
+            _two_file_context(),
+            provider=provider,
+            ai_config=AIConfig(
+                enabled=True,
+                transport=AITransport.CLI,
+                max_parallel_calls=1,
+            ),
+            depth=1,
+            checklist_items=[],
+            checklist_text="1. [logic-bug] Example?",
+            classifications=[],
+            stop=stop,
+        )
+
+    assert_that(result.metadata.partial).is_true()
+    assert_that(result.metadata.stopped_reason).contains("SIGTERM")
+    assert_that(result.metadata.chunks_reviewed).is_equal_to(1)
+    assert_that({record.path for record in result.coverage_records}).contains("a.py")
+
+
 def test_sigterm_timeout_error_classifies_as_timeout() -> None:
     """The SIGTERM envelope must reuse the persistable TIMEOUT kind."""
     error = sigterm_timeout_error()

--- a/tests/unit/ai/review/test_orchestrator.py
+++ b/tests/unit/ai/review/test_orchestrator.py
@@ -20,8 +20,10 @@ from lintro.ai.review.enums.file_skip_reason import FileSkipReason
 from lintro.ai.review.enums.finding_status import FindingStatus
 from lintro.ai.review.enums.review_category import ReviewCategory
 from lintro.ai.review.enums.review_strictness import ReviewStrictness
+from lintro.ai.review.errors_taxonomy import ReviewErrorKind, classify_provider_error
 from lintro.ai.review.exceptions import ReviewExecutionError
 from lintro.ai.review.group_labels import REL_SINGLE_FILE
+from lintro.ai.review.interrupt import SIGTERM_TIMEOUT_MESSAGE, sigterm_timeout_error
 from lintro.ai.review.models.changed_file import ChangedFile
 from lintro.ai.review.models.checklist_item import ChecklistItem
 from lintro.ai.review.models.coverage_record import CoverageRecord
@@ -36,6 +38,7 @@ from lintro.ai.review.orchestrator import (
     parse_review_response,
     resolve_review_chunks,
     run_review,
+    run_review_async,
     strip_json_fences,
 )
 from lintro.ai.review.progress import ReviewProgressCallback
@@ -306,6 +309,86 @@ def test_run_review_returns_partial_on_chunk_timeout() -> None:
     assert_that(result.metadata.chunks_reviewed).is_equal_to(1)
     assert_that(result.metadata.chunks_total).is_equal_to(2)
     assert_that({record.path for record in result.coverage_records}).contains("a.py")
+
+
+@pytest.mark.asyncio
+async def test_run_review_returns_partial_on_sigterm() -> None:
+    """A mid-run SIGTERM persists completed chunks instead of aborting."""
+    provider = _mock_provider(content=_sample_response_json(finding_file="a.py"))
+    chunks = [
+        ReviewChunk(
+            id=1,
+            files=["a.py"],
+            diff="diff --git a/a.py b/a.py\n+x",
+            relationship=REL_SINGLE_FILE,
+        ),
+        ReviewChunk(
+            id=2,
+            files=["b.py"],
+            diff="diff --git a/b.py b/b.py\n+y",
+            relationship=REL_SINGLE_FILE,
+        ),
+    ]
+    seen: list[str] = []
+    stop = asyncio.Event()
+
+    async def _hang_second_call(
+        *,
+        provider,
+        user_prompt,
+        budget=None,
+        **kwargs,
+    ):  # noqa: ANN001, ANN003, ANN202
+        del budget
+        seen.append("call")
+        if len(seen) >= 2:
+            stop.set()
+            await asyncio.sleep(60)
+        return provider.complete(
+            user_prompt,
+            system=kwargs.get("system_prompt"),
+            max_tokens=kwargs.get("max_tokens", 1024),
+        )
+
+    with (
+        patch(
+            "lintro.ai.review.orchestrator.resolve_review_chunks",
+            return_value=chunks,
+        ),
+        patch(
+            "lintro.ai.review.orchestrator.call_ai",
+            side_effect=_hang_second_call,
+        ),
+    ):
+        result = await run_review_async(
+            _two_file_context(),
+            provider=provider,
+            ai_config=AIConfig(
+                enabled=True,
+                transport=AITransport.CLI,
+                max_parallel_calls=1,
+            ),
+            depth=1,
+            checklist_items=[],
+            checklist_text="1. [logic-bug] Example?",
+            classifications=[],
+            stop=stop,
+        )
+
+    assert_that(result.metadata.partial).is_true()
+    assert_that(result.metadata.stopped_reason).contains("timeout")
+    assert_that(result.metadata.stopped_reason).contains("SIGTERM")
+    assert_that(result.metadata.chunks_reviewed).is_equal_to(1)
+    assert_that({record.path for record in result.coverage_records}).contains("a.py")
+
+
+def test_sigterm_timeout_error_classifies_as_timeout() -> None:
+    """The SIGTERM envelope must reuse the persistable TIMEOUT kind."""
+    error = sigterm_timeout_error()
+    assert_that(str(error)).is_equal_to(SIGTERM_TIMEOUT_MESSAGE)
+    assert_that(classify_provider_error(provider="", error=error)).is_equal_to(
+        ReviewErrorKind.TIMEOUT,
+    )
 
 
 def test_run_review_writes_incremental_coverage_parts(

--- a/tests/unit/cli/test_review_command.py
+++ b/tests/unit/cli/test_review_command.py
@@ -53,6 +53,28 @@ def _empty_result() -> ReviewResult:
     )
 
 
+def _partial_result(*, stopped_reason: str) -> ReviewResult:
+    return ReviewResult(
+        metadata=ReviewMetadata(
+            model="gpt-4o",
+            provider="openai",
+            context_window=128_000,
+            depth=1,
+            chunks_total=2,
+            chunks_current=1,
+            files_reviewed=1,
+            files_total=2,
+            checklist_items=0,
+            partial=True,
+            chunks_reviewed=1,
+            stopped_reason=stopped_reason,
+        ),
+        summary="Partial review.",
+        checklist=(),
+        findings=(),
+    )
+
+
 def test_review_help_shows_flags() -> None:
     """Review command help lists primary flags."""
     runner = CliRunner()
@@ -1787,6 +1809,113 @@ def test_full_review_json_merges_advisory_key() -> None:
     payload = json.loads(result.output)
     assert_that(payload["summary"]).is_equal_to("ok")
     assert_that(payload["advisory"][0]["tool"]).is_equal_to("idiom-review")
+
+
+def test_sigterm_partial_skips_advisory_and_post() -> None:
+    """Runner SIGTERM must exit after the envelope, not burn the 5s window."""
+    runner = CliRunner()
+    patches = _mock_review_pipeline()
+
+    with (
+        patches["require_ai"],
+        patches["get_config"],
+        patches["collect_review_context"],
+        patches["classify_changed_files"],
+        patches["get_all_checklist_items"],
+        patches["select_checklist_items"],
+        patches["format_checklist_for_prompt"],
+        patches["get_provider"],
+        patch(
+            "lintro.cli_utils.commands.review.run_review",
+            return_value=_partial_result(stopped_reason="timeout (SIGTERM)"),
+        ),
+        patch(
+            "lintro.cli_utils.commands.review.render_review_output",
+            return_value=json.dumps({"summary": "partial", "partial": True}),
+        ),
+        patch(
+            "lintro.cli_utils.commands.review.run_advisory_tools",
+            return_value=[_advisory_finding_result()],
+        ) as mock_advisory,
+        patch(
+            "lintro.ai.review.github.post_review_to_github",
+            return_value=True,
+        ) as mock_post,
+    ):
+        result = runner.invoke(
+            cli,
+            [
+                "review",
+                "--post",
+                "--pr",
+                "7",
+                "--repo",
+                "owner/name",
+                "--output",
+                "json",
+                "--advisory-tools",
+                "idiom-review",
+            ],
+        )
+
+    assert_that(result.exit_code).is_equal_to(0)
+    payload = json.loads(result.output)
+    assert_that(payload["summary"]).is_equal_to("partial")
+    assert_that(payload).does_not_contain_key("advisory")
+    assert_that(mock_advisory.called).is_false()
+    assert_that(mock_post.called).is_false()
+
+
+def test_cost_cap_partial_still_runs_advisory_and_post() -> None:
+    """A cost-cap stop is not a runner SIGKILL window; --post still runs."""
+    runner = CliRunner()
+    patches = _mock_review_pipeline()
+
+    with (
+        patches["require_ai"],
+        patches["get_config"],
+        patches["collect_review_context"],
+        patches["classify_changed_files"],
+        patches["get_all_checklist_items"],
+        patches["select_checklist_items"],
+        patches["format_checklist_for_prompt"],
+        patches["get_provider"],
+        patch(
+            "lintro.cli_utils.commands.review.run_review",
+            return_value=_partial_result(stopped_reason="cost cap ($1.00) reached"),
+        ),
+        patch(
+            "lintro.cli_utils.commands.review.render_review_output",
+            return_value=json.dumps({"summary": "partial", "partial": True}),
+        ),
+        patch(
+            "lintro.cli_utils.commands.review.run_advisory_tools",
+            return_value=[],
+        ) as mock_advisory,
+        patch(
+            "lintro.ai.review.github.post_review_to_github",
+            return_value=True,
+        ) as mock_post,
+    ):
+        result = runner.invoke(
+            cli,
+            [
+                "review",
+                "--post",
+                "--pr",
+                "7",
+                "--repo",
+                "owner/name",
+                "--output",
+                "json",
+                "--advisory-tools",
+                "idiom-review",
+            ],
+        )
+
+    assert_that(result.exit_code).is_equal_to(0)
+    assert_that(mock_advisory.called).is_true()
+    assert_that(mock_post.called).is_true()
 
 
 def test_full_review_keeps_results_when_advisory_errors() -> None:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(ai-review): persist coverage when the runner sends SIGTERM
  ```

- Type:
  - [x] fix / perf (patch)
  - [ ] feat (minor)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What’s Changing

#2166's 14-chunk dogfood still dies at ~1030s with **exit 143** even after #2167/#2168 landed 1800s + persist-on-timeout. The review step produces no JSON envelope, `if: always()` artifact upload is skipped, and resume has nothing to download.

This PR treats runner SIGTERM like the existing mid-round timeout:

- Install a SIGTERM/SIGINT handler that stops the review cooperatively and persists completed chunks via the existing INCOMPLETE path
- Start the agent CLI in a new session so an agent `killpg` cannot take lintro with it
- Forward SIGTERM to the lintro PID, write the JSON envelope to a file (not a `tee` pipe that dies with the process group), and heartbeat the Actions log
- Reap the TERM-immune log mirror with SIGKILL (`90297b83`)
- Skip advisory tools and `--post` on a SIGTERM partial so the ~5s SIGKILL window is spent classifying the envelope and uploading state (`ebc81842`). Cost-cap partials still post.

Do **not** merge #2165/#2166 as terraform/SPDX. After this lands, retrigger #2166 so `base.sha` installs the SIGTERM persist path.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [ ] Docs updated if user-facing
- [x] Local tests passed (orchestrator / CLI transport / run-ai-review / review command)

## Related Issues

Related #2156
Related #2166
Related #2167

## Details

Live evidence (same ~17 min SIGTERM with persist+1800s already on `base.sha`):

- https://github.com/lgtm-hq/py-lintro/actions/runs/32792961133
- Review step 00:18:31Z–00:35:41Z, exit 143, no artifact, upload skipped

**Fable:** approve on `90297b83` (P2: tail killed before envelope flush — bounded 2s `--pid` wait added). **Sol:** approve on `90297b83`.

Accepted residuals:

- `custom_agents: only` mid-call SIGTERM still not wired
- `add_signal_handler` does not restore a prior embedder handler
- second Ctrl+C does not escalate
- `start_new_session` orphans an agent only if lintro dies without `_terminate` (in-flight cancel already `killpg`s)
- Full wrapper-driven fake-lintro SIGTERM harness is out of scope; helper + persist paths are unit-tested

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0ff3c26c-cf67-4c32-bff9-30643bc047b9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0ff3c26c-cf67-4c32-bff9-30643bc047b9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * AI reviews now handle termination gracefully, preserving completed results and coverage for later continuation.
  * Interrupted reviews provide a clear resume hint and timeout status.
  * CLI subprocess cleanup now reliably terminates related child processes.

* **Bug Fixes**
  * Improved CI review handling during runner shutdowns, including output persistence and signal forwarding.
  * Added periodic progress heartbeats while reviews are running.
  * Partial reviews now avoid publishing incomplete advisory results.

* **Tests**
  * Expanded coverage for interrupted reviews, subprocess cleanup, persistence, and timeout handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->