### PR TITLE
fix(ci): persist review-state across runner cancel

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -286,6 +286,24 @@ jobs:
       - name: Install dependencies
         run: uv sync --extra ai
 
+      - name: Expose Actions runtime for state upload
+        # run: steps do not receive ACTIONS_RUNTIME_TOKEN /
+        # ACTIONS_RESULTS_URL (runner Node/container actions do).
+        # Export masked outputs so the review step can upload
+        # checkpoints before a cancel skips later always() steps.
+        id: artifact-runtime
+        # yamllint disable-line rule:line-length
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          script: |
+            const token = process.env.ACTIONS_RUNTIME_TOKEN || ''
+            const results = process.env.ACTIONS_RESULTS_URL || ''
+            if (token) {
+              core.setSecret(token)
+            }
+            core.setOutput('runtime-token', token)
+            core.setOutput('results-url', results)
+
       - name: Mint lintro-review App token
         id: lintro-review-app
         # Repo-scoped installation token (#2050). Default current-repo scope —
@@ -348,6 +366,10 @@ jobs:
           # transport treats a numeric cap as a runtime bound, not
           # marginal dollars, under subscription auth.
           LINTRO_AI_MAX_COST_USD: ${{ vars.LINTRO_AI_MAX_COST_USD }}
+          # In-step persist upload (#2173). Masked outputs from the
+          # github-script step above; blank when the runner omitted them.
+          ACTIONS_RUNTIME_TOKEN: ${{ steps.artifact-runtime.outputs.runtime-token }}
+          ACTIONS_RESULTS_URL: ${{ steps.artifact-runtime.outputs.results-url }}
 
       - name: Upload review-state artifacts
         # Final upload is best-effort. A cancelled job skips later

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -159,11 +159,12 @@ jobs:
         # GitHub releases CDN; those runs blocked it and the action fell
         # back to nodejs.org — allowlisted so Node install is not a silent
         # fallback.
-        # pipelines.actions.githubusercontent.com is the artifact service
-        # (#2158 / test-ci.yml precedent). This job forbids wildcard
-        # endpoints, so `*.blob.core.windows.net` (used by publish jobs)
-        # cannot be copied here. No additional blob-redirect host has
-        # been observed on artifact upload/download in this repo.
+        # pipelines.actions.githubusercontent.com and
+        # results-receiver.actions.githubusercontent.com are the artifact
+        # service (#2158 / in-step persist upload). This job forbids
+        # wildcard endpoints, so `*.blob.core.windows.net` (used by
+        # publish jobs) cannot be copied here. No additional blob-redirect
+        # host has been observed on artifact upload/download in this repo.
         # yamllint disable-line rule:line-length
         uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
         with:
@@ -176,6 +177,7 @@ jobs:
             raw.githubusercontent.com:443
             release-assets.githubusercontent.com:443
             pipelines.actions.githubusercontent.com:443
+            results-receiver.actions.githubusercontent.com:443
             api.anthropic.com:443
             astral.sh:443
             releases.astral.sh:443
@@ -348,13 +350,11 @@ jobs:
           LINTRO_AI_MAX_COST_USD: ${{ vars.LINTRO_AI_MAX_COST_USD }}
 
       - name: Upload review-state artifacts
-        # Final upload is best-effort. Empirically, a cancelled mid-job
-        # step caused later always() uploads to skip (dogfood job
-        # 97293667852, 2026-08-24). Incremental ``state.json`` writes
-        # (#2154/#2156) are runner-local until this step; they survive
-        # SIGTERM of the review process, not a skipped always() upload.
-        # lintro now traps SIGTERM, writes state.json, and exits with a
-        # JSON envelope so this step can still run after a runner signal.
+        # Final upload is best-effort. A cancelled job skips later
+        # always() steps (dogfood #2166 round 5 / job 97293667852).
+        # run-ai-review.sh uploads checkpoints and an inline snapshot
+        # from inside the review step so persist survives that skip.
+        # This step still runs on a clean or step-timeout finish.
         # if-no-files-found: ignore so pre-feature runs no-op.
         if: always()
         # yamllint disable-line rule:line-length

--- a/.prettierignore
+++ b/.prettierignore
@@ -5,6 +5,10 @@ node_modules
 .venv
 .lintro
 
+# Standalone prettier in dogfood has no astro parser. astro-check covers
+# these files; prettier-plugin-astro is not loaded without node_modules.
+*.astro
+
 
 # AI prompt templates (not human docs; keep verbatim)
 lintro/ai/prompts/templates/**

--- a/docs/adr/0007-review-resume-and-artifact-state.md
+++ b/docs/adr/0007-review-resume-and-artifact-state.md
@@ -43,7 +43,8 @@ cost cap: coverage and this-run findings already written are persisted (incremen
 `part-*.json` under `LINTRO_REVIEW_STATE_DIR`) and the next round resumes. A SIGTERM
 after a finished chunk must not lose that chunk's coverage or issues. The wrapper
 uploads those parts from inside the review step: a cancelled Actions job skips later
-`if: always()` uploads, and `wait` 143 after persist is classified as INCOMPLETE.
+`if: always()` uploads. After `wait` reports 143, the persisted envelope decides the
+outcome: incomplete coverage is INCOMPLETE, and complete coverage stays REVIEWED.
 
 `conftest.py` is a known semantic hole (test-wide fixtures) left on the revisit list.
 

--- a/docs/adr/0007-review-resume-and-artifact-state.md
+++ b/docs/adr/0007-review-resume-and-artifact-state.md
@@ -45,8 +45,8 @@ after a finished chunk must not lose that chunk's coverage or issues. The wrappe
 uploads those parts from inside the review step: a cancelled Actions job skips later
 `if: always()` uploads. The post-wait inline upload is capped at 2s (Create/PUT/Finalize
 together, plus a `timeout(1)` hard kill) so classify still runs inside GitHub's ~7.5s
-SIGTERM grace. After `wait` reports 143, the persisted envelope decides the
-outcome: incomplete coverage is INCOMPLETE, and complete coverage stays REVIEWED.
+SIGTERM grace. After `wait` reports 143, the persisted envelope decides the outcome:
+incomplete coverage is INCOMPLETE, and complete coverage stays REVIEWED.
 
 `conftest.py` is a known semantic hole (test-wide fixtures) left on the revisit list.
 

--- a/docs/adr/0007-review-resume-and-artifact-state.md
+++ b/docs/adr/0007-review-resume-and-artifact-state.md
@@ -43,7 +43,9 @@ cost cap: coverage and this-run findings already written are persisted (incremen
 `part-*.json` under `LINTRO_REVIEW_STATE_DIR`) and the next round resumes. A SIGTERM
 after a finished chunk must not lose that chunk's coverage or issues. The wrapper
 uploads those parts from inside the review step: a cancelled Actions job skips later
-`if: always()` uploads. After `wait` reports 143, the persisted envelope decides the
+`if: always()` uploads. The post-wait inline upload is capped at 2s (Create/PUT/Finalize
+together, plus a `timeout(1)` hard kill) so classify still runs inside GitHub's ~7.5s
+SIGTERM grace. After `wait` reports 143, the persisted envelope decides the
 outcome: incomplete coverage is INCOMPLETE, and complete coverage stays REVIEWED.
 
 `conftest.py` is a known semantic hole (test-wide fixtures) left on the revisit list.

--- a/docs/adr/0007-review-resume-and-artifact-state.md
+++ b/docs/adr/0007-review-resume-and-artifact-state.md
@@ -41,7 +41,9 @@ partial review cannot render clean or pass the AI Review check. Large capped API
 are red on round 1 by design. A mid-round **timeout** is the same class of stop as a
 cost cap: coverage and this-run findings already written are persisted (incremental
 `part-*.json` under `LINTRO_REVIEW_STATE_DIR`) and the next round resumes. A SIGTERM
-after a finished chunk must not lose that chunk's coverage or issues.
+after a finished chunk must not lose that chunk's coverage or issues. The wrapper
+uploads those parts from inside the review step: a cancelled Actions job skips later
+`if: always()` uploads, and `wait` 143 after persist is classified as INCOMPLETE.
 
 `conftest.py` is a known semantic hole (test-wide fixtures) left on the revisit list.
 

--- a/scripts/ci/classify_review_outcome.py
+++ b/scripts/ci/classify_review_outcome.py
@@ -70,6 +70,11 @@ NO_CREDENTIAL_STATUS: Final[int] = -1
 # red check that does not say why is only marginally better than a green one.
 NOT_INVOKED_STATUS: Final[int] = -2
 
+# 128 + SIGTERM. The wrapper's ``wait`` reports this when the runner signals
+# the step even if ``lintro review`` already wrote a persist envelope and
+# exited 0. Treat that envelope as the outcome, not "unexpected status 143".
+SIGTERM_STATUS: Final[int] = 143
+
 DEFAULT_TRANSPORT: Final[str] = "cli"
 
 # Kind labels refined for the active transport. Shared kinds stay as-is;
@@ -176,9 +181,19 @@ def _parse_coverage_envelope(*, text: str) -> dict[str, Any] | None:
         if isinstance(payload, dict) and "readiness_verdict" in payload:
             coverage = payload.get("coverage")
             if isinstance(coverage, dict):
+                if "stopped_reason" not in coverage and payload.get("stopped_reason"):
+                    coverage = {
+                        **coverage,
+                        "stopped_reason": payload.get("stopped_reason"),
+                    }
                 return coverage
             if payload.get("readiness_verdict") == "incomplete":
-                return {"complete": False, "covered_at_head": 0, "eligible": 0}
+                return {
+                    "complete": False,
+                    "covered_at_head": 0,
+                    "eligible": 0,
+                    "stopped_reason": payload.get("stopped_reason") or "",
+                }
         index = text.find("{", index + 1)
     return None
 
@@ -236,6 +251,64 @@ def _with_transport(*, transport: str, headline: str) -> str:
         Headline that always names the transport.
     """
     return f"[{transport}] {headline}"
+
+
+def _incomplete_report(
+    *,
+    coverage: dict[str, Any],
+    transport: str,
+) -> OutcomeReport:
+    """Build the INCOMPLETE outcome from a parsed coverage envelope.
+
+    Args:
+        coverage: Coverage mapping from the review JSON envelope.
+        transport: Active transport named on the headline.
+
+    Returns:
+        Report that reddens the check and tells the next round to resume.
+    """
+    covered = coverage.get("covered_at_head", 0)
+    eligible = coverage.get("eligible", 0)
+    return OutcomeReport(
+        outcome=ReviewOutcome.INCOMPLETE,
+        headline=_with_transport(
+            transport=transport,
+            headline=(
+                "review incomplete — "
+                f"{covered}/{eligible} files covered at HEAD; "
+                "next round resumes"
+            ),
+        ),
+        detail=str(coverage.get("stopped_reason") or ""),
+        exit_code=1,
+        transport=transport,
+    )
+
+
+def _reviewed_report(*, findings: bool, transport: str) -> OutcomeReport:
+    """Build the REVIEWED outcome for a finished envelope.
+
+    Args:
+        findings: True when the review posted P1 findings.
+        transport: Active transport named on the headline.
+
+    Returns:
+        Green report; the review itself produced a result.
+    """
+    return OutcomeReport(
+        outcome=ReviewOutcome.REVIEWED,
+        headline=_with_transport(
+            transport=transport,
+            headline=(
+                "reviewed — P1 findings posted"
+                if findings
+                else "reviewed — no P1 findings"
+            ),
+        ),
+        detail="",
+        exit_code=0,
+        transport=transport,
+    )
 
 
 def refine_failure_kind(
@@ -338,38 +411,16 @@ def classify(
             transport=transport,
         )
 
+    # A persist envelope wins over the wrapper exit status. ``wait`` reports
+    # 143 when the runner SIGTERMs the step after lintro already wrote
+    # INCOMPLETE JSON and exited 0 (#2156 / #2166 round 5).
+    coverage = _parse_coverage_envelope(text=output)
+    if coverage is not None and not coverage.get("complete", True):
+        return _incomplete_report(coverage=coverage, transport=transport)
+
     if status in (REVIEW_STATUS_CLEAN, REVIEW_STATUS_FINDINGS):
-        coverage = _parse_coverage_envelope(text=output)
-        if coverage is not None and not coverage.get("complete", True):
-            covered = coverage.get("covered_at_head", 0)
-            eligible = coverage.get("eligible", 0)
-            return OutcomeReport(
-                outcome=ReviewOutcome.INCOMPLETE,
-                headline=_with_transport(
-                    transport=transport,
-                    headline=(
-                        "review incomplete — "
-                        f"{covered}/{eligible} files covered at HEAD; "
-                        "next round resumes"
-                    ),
-                ),
-                detail=str(coverage.get("stopped_reason") or ""),
-                exit_code=1,
-                transport=transport,
-            )
-        findings = status == REVIEW_STATUS_FINDINGS
-        return OutcomeReport(
-            outcome=ReviewOutcome.REVIEWED,
-            headline=_with_transport(
-                transport=transport,
-                headline=(
-                    "reviewed — P1 findings posted"
-                    if findings
-                    else "reviewed — no P1 findings"
-                ),
-            ),
-            detail="",
-            exit_code=0,
+        return _reviewed_report(
+            findings=status == REVIEW_STATUS_FINDINGS,
             transport=transport,
         )
 
@@ -391,6 +442,10 @@ def classify(
     )
 
     if status != REVIEW_STATUS_ERROR:
+        # ``wait`` can report SIGTERM after a finished review already wrote a
+        # complete envelope. Prefer that over "unexpected status 143".
+        if coverage is not None and coverage.get("complete", True):
+            return _reviewed_report(findings=False, transport=transport)
         # An exit status lintro does not define means the wrapper itself broke
         # (missing dependency, bad flag, crash). Never attribute that to the
         # provider — the fix is in lintro, not in the account.

--- a/scripts/ci/classify_review_outcome.py
+++ b/scripts/ci/classify_review_outcome.py
@@ -45,6 +45,7 @@ import json
 import os
 import re
 import sys
+from collections.abc import Mapping
 from dataclasses import dataclass
 from enum import StrEnum, auto
 from pathlib import Path
@@ -161,6 +162,27 @@ class OutcomeReport:
     transport: str = DEFAULT_TRANSPORT
 
 
+def _payload_has_p1_findings(payload: Mapping[str, Any]) -> bool:
+    """Return whether a review envelope lists any P1 finding.
+
+    Args:
+        payload: Decoded review JSON object.
+
+    Returns:
+        True when any finding severity is ``P1``.
+    """
+    findings = payload.get("findings")
+    if not isinstance(findings, list):
+        return False
+    for item in findings:
+        if not isinstance(item, Mapping):
+            continue
+        severity = str(item.get("severity") or "").upper()
+        if severity in {"P1", "SEVERITY.P1"}:
+            return True
+    return False
+
+
 def _parse_coverage_envelope(*, text: str) -> dict[str, Any] | None:
     """Extract the coverage object from a successful review JSON envelope.
 
@@ -180,19 +202,22 @@ def _parse_coverage_envelope(*, text: str) -> dict[str, Any] | None:
             continue
         if isinstance(payload, dict) and "readiness_verdict" in payload:
             coverage = payload.get("coverage")
+            extras = {
+                "stopped_reason": payload.get("stopped_reason") or "",
+                "has_p1_findings": _payload_has_p1_findings(payload),
+            }
             if isinstance(coverage, dict):
-                if "stopped_reason" not in coverage and payload.get("stopped_reason"):
-                    coverage = {
-                        **coverage,
-                        "stopped_reason": payload.get("stopped_reason"),
-                    }
-                return coverage
+                merged = {**coverage}
+                if not merged.get("stopped_reason") and extras["stopped_reason"]:
+                    merged["stopped_reason"] = extras["stopped_reason"]
+                merged["has_p1_findings"] = extras["has_p1_findings"]
+                return merged
             if payload.get("readiness_verdict") == "incomplete":
                 return {
                     "complete": False,
                     "covered_at_head": 0,
                     "eligible": 0,
-                    "stopped_reason": payload.get("stopped_reason") or "",
+                    **extras,
                 }
         index = text.find("{", index + 1)
     return None
@@ -445,7 +470,10 @@ def classify(
         # ``wait`` can report SIGTERM after a finished review already wrote a
         # complete envelope. Prefer that over "unexpected status 143".
         if coverage is not None and coverage.get("complete", True):
-            return _reviewed_report(findings=False, transport=transport)
+            return _reviewed_report(
+                findings=bool(coverage.get("has_p1_findings")),
+                transport=transport,
+            )
         # An exit status lintro does not define means the wrapper itself broke
         # (missing dependency, bad flag, crash). Never attribute that to the
         # provider — the fix is in lintro, not in the account.

--- a/scripts/ci/review_state_artifacts.py
+++ b/scripts/ci/review_state_artifacts.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Locate prior AI-review state artifacts across workflow runs (#2158).
+"""Locate and upload AI-review state artifacts (#2158 / #2156).
 
 Cross-run download is not ``download-artifact``'s default. This helper lists
 completed trusted runs of ``ai-review.yml`` and prints the newest run that
@@ -7,25 +7,37 @@ carries a valid ``lintro-review-state-pr-<N>-*`` artifact. The current run is
 excluded. Conclusion is irrelevant: an INCOMPLETE (red) round is exactly the
 run to resume from (#2154).
 
+``upload`` writes the current ``ai-review-state/`` directory through the
+Actions artifact service from inside ``run-ai-review.sh``. A cancelled job
+skips later ``if: always()`` steps (dogfood #2166 round 5); an in-step
+upload still attaches the persist snapshot so the next run can resume.
+
 Missing, expired, unlistable, or malformed state degrades to empty — a full
 re-review — and never fails the job. Lintro writes versioned parts under
-``ai-review-state/`` (#2154); this helper only locates the prior run.
+``ai-review-state/`` (#2154).
 """
 
 from __future__ import annotations
 
 import argparse
+import base64
+import hashlib
+import io
 import json
 import os
 import re
 import shutil
 import subprocess  # nosec B404 - gh argv is built internally; shell=False
 import sys
+import urllib.error
+import urllib.request
+import zipfile
 from collections.abc import Callable, Iterator, Mapping, Sequence
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any, Final
+from urllib.parse import urlparse
 
 WORKFLOW_FILENAME: Final[str] = "ai-review.yml"
 WORKFLOW_PATH: Final[str] = f".github/workflows/{WORKFLOW_FILENAME}"
@@ -35,9 +47,13 @@ _STATE_NAME_RE: Final[re.Pattern[str]] = re.compile(
     rf"^{re.escape(STATE_ARTIFACT_PREFIX)}(\d+)-",
 )
 _GH_API_TIMEOUT_SECONDS: Final[int] = 30
+_UPLOAD_TIMEOUT_SECONDS: Final[int] = 15
 RUNS_PER_PAGE: Final[int] = 100
 ARTIFACTS_PER_PAGE: Final[int] = 100
 RETENTION_DAYS: Final[int] = 30
+DEFAULT_STATE_DIR: Final[str] = "ai-review-state"
+TWIRP_SERVICE: Final[str] = "github.actions.results.api.v1.ArtifactService"
+RESULTS_HOST_SUFFIX: Final[str] = ".actions.githubusercontent.com"
 
 
 @dataclass(frozen=True)
@@ -77,6 +93,7 @@ class WorkflowRun:
 
 GhApi = Callable[[str], Any | None]
 ApiObject = Mapping[str, Any]
+HttpDo = Callable[[str, str, Mapping[str, str], bytes], tuple[int, bytes]]
 
 
 def state_artifact_prefix(pr_number: int) -> str:
@@ -535,19 +552,330 @@ def locate_from_env(
         return None
 
 
+def state_files(directory: Path) -> list[Path]:
+    """Return JSON state files in ``directory``.
+
+    Args:
+        directory: Review-state directory.
+
+    Returns:
+        Sorted JSON paths. Missing directories yield empty.
+    """
+    if not directory.is_dir():
+        return []
+    return sorted(
+        path
+        for path in directory.iterdir()
+        if path.is_file() and path.suffix == ".json"
+    )
+
+
+def sanitize_artifact_suffix(raw: str) -> str:
+    """Return a filename-safe artifact-name suffix.
+
+    Args:
+        raw: Caller-supplied suffix (``inline``, ``ckpt-15``, ...).
+
+    Returns:
+        Sanitized suffix; empty input becomes ``inline``.
+    """
+    cleaned = re.sub(r"[^A-Za-z0-9._-]+", "-", (raw or "").strip())
+    cleaned = cleaned.replace("..", "-")
+    cleaned = re.sub(r"-{2,}", "-", cleaned).strip("-.")
+    return cleaned or "inline"
+
+
+def state_artifact_name(*, pr_number: int, attempt: int, suffix: str) -> str:
+    """Return the artifact name for one in-step upload.
+
+    Args:
+        pr_number: Pull request number.
+        attempt: ``GITHUB_RUN_ATTEMPT``.
+        suffix: Distinguisher so v4 can upload more than once per run.
+
+    Returns:
+        Name matching ``lintro-review-state-pr-<N>-*``.
+    """
+    return (
+        f"{STATE_ARTIFACT_PREFIX}{pr_number}-attempt-{attempt}-"
+        f"{sanitize_artifact_suffix(suffix)}"
+    )
+
+
+def zip_state_files(files: Sequence[Path]) -> bytes:
+    """Zip state files at the archive root.
+
+    Args:
+        files: JSON files to include.
+
+    Returns:
+        Zip bytes.
+    """
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+        for path in files:
+            archive.write(path, arcname=path.name)
+    return buffer.getvalue()
+
+
+def backend_ids_from_token(token: str) -> tuple[str, str] | None:
+    """Read Actions Results backend IDs from the runtime JWT.
+
+    Args:
+        token: ``ACTIONS_RUNTIME_TOKEN``.
+
+    Returns:
+        ``(workflow_run_backend_id, workflow_job_run_backend_id)``, or
+        ``None`` when the token is not an Actions Results JWT.
+    """
+    parts = token.split(".")
+    if len(parts) < 2:
+        return None
+    padded = parts[1] + "=" * (-len(parts[1]) % 4)
+    try:
+        payload = json.loads(base64.urlsafe_b64decode(padded))
+    except (ValueError, json.JSONDecodeError, UnicodeError):
+        return None
+    if not isinstance(payload, Mapping):
+        return None
+    scp = str(payload.get("scp", ""))
+    for scope in scp.split():
+        bits = scope.split(":")
+        if len(bits) == 3 and bits[0] == "Actions.Results":
+            return bits[1], bits[2]
+    return None
+
+
+def _results_origin(results_url: str) -> str | None:
+    """Return the origin of ``ACTIONS_RESULTS_URL`` when it is trusted.
+
+    Args:
+        results_url: Raw results-service URL.
+
+    Returns:
+        ``scheme://host`` origin, or ``None`` when the host is not an
+        Actions results endpoint.
+    """
+    parsed = urlparse(results_url)
+    host = (parsed.hostname or "").lower()
+    if parsed.scheme != "https" or not host.endswith(RESULTS_HOST_SUFFIX):
+        return None
+    return f"{parsed.scheme}://{parsed.netloc}"
+
+
+def _http_do(
+    method: str,
+    url: str,
+    headers: Mapping[str, str],
+    body: bytes,
+) -> tuple[int, bytes]:
+    """Issue one HTTPS request.
+
+    Args:
+        method: HTTP method.
+        url: Absolute HTTPS URL.
+        headers: Request headers.
+        body: Request body; empty for no payload.
+
+    Returns:
+        Status code and response body. HTTP errors are returned, not raised.
+    """
+    parsed = urlparse(url)
+    if parsed.scheme != "https":
+        return 0, b"refusing non-https artifact URL"
+    request = urllib.request.Request(  # noqa: S310 - scheme checked above
+        url,
+        data=body or None,
+        method=method,
+        headers=dict(headers),
+    )
+    try:
+        with urllib.request.urlopen(  # nosec B310 - https-only; URL from Actions
+            request,
+            timeout=_UPLOAD_TIMEOUT_SECONDS,
+        ) as response:
+            return int(response.status), response.read()
+    except urllib.error.HTTPError as exc:
+        return int(exc.code), exc.read()
+    except (OSError, urllib.error.URLError):
+        return 0, b"artifact request failed"
+
+
+def _twirp_json(
+    *,
+    origin: str,
+    method: str,
+    token: str,
+    payload: Mapping[str, Any],
+    http_do: HttpDo,
+) -> dict[str, Any] | None:
+    """Call one ArtifactService Twirp method.
+
+    Args:
+        origin: Results-service origin.
+        method: Twirp method name.
+        token: Runtime token.
+        payload: JSON body (proto field names).
+        http_do: Injectable HTTP client.
+
+    Returns:
+        Decoded object, or ``None`` on failure.
+    """
+    url = f"{origin}/twirp/{TWIRP_SERVICE}/{method}"
+    status, body = http_do(
+        "POST",
+        url,
+        {
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+        },
+        json.dumps(payload).encode("utf-8"),
+    )
+    if status < 200 or status >= 300:
+        return None
+    try:
+        decoded = json.loads(body.decode("utf-8"))
+    except (UnicodeError, json.JSONDecodeError):
+        return None
+    return decoded if isinstance(decoded, dict) else None
+
+
+def upload_state(
+    *,
+    directory: Path,
+    name: str,
+    token: str,
+    results_url: str,
+    http_do: HttpDo = _http_do,
+) -> bool:
+    """Upload JSON state files as one Actions artifact.
+
+    Args:
+        directory: Directory holding ``state.json`` / ``part-*.json``.
+        name: Artifact name.
+        token: ``ACTIONS_RUNTIME_TOKEN``.
+        results_url: ``ACTIONS_RESULTS_URL``.
+        http_do: Injectable HTTP client.
+
+    Returns:
+        True when Create + PUT + Finalize all succeeded.
+    """
+    files = state_files(directory)
+    origin = _results_origin(results_url)
+    ids = backend_ids_from_token(token)
+    if not files or origin is None or ids is None:
+        return False
+    archive = zip_state_files(files)
+    digest = hashlib.sha256(archive).hexdigest()
+    created = _twirp_json(
+        origin=origin,
+        method="CreateArtifact",
+        token=token,
+        payload={
+            "workflow_run_backend_id": ids[0],
+            "workflow_job_run_backend_id": ids[1],
+            "name": name,
+            "version": 4,
+            "mime_type": {"value": "application/zip"},
+        },
+        http_do=http_do,
+    )
+    if created is None or not created.get("ok", True):
+        return False
+    signed = created.get("signed_upload_url") or created.get("signedUploadUrl")
+    if not isinstance(signed, str) or not signed:
+        return False
+    put_status, _put_body = http_do(
+        "PUT",
+        signed,
+        {
+            "Content-Type": "application/zip",
+            "x-ms-blob-type": "BlockBlob",
+            "x-ms-blob-content-type": "application/zip",
+        },
+        archive,
+    )
+    if put_status < 200 or put_status >= 300:
+        return False
+    finalized = _twirp_json(
+        origin=origin,
+        method="FinalizeArtifact",
+        token=token,
+        payload={
+            "workflow_run_backend_id": ids[0],
+            "workflow_job_run_backend_id": ids[1],
+            "name": name,
+            "size": str(len(archive)),
+            "hash": {"value": f"sha256:{digest}"},
+        },
+        http_do=http_do,
+    )
+    return bool(finalized is not None and finalized.get("ok", True))
+
+
+def upload_from_env(
+    env: Mapping[str, str],
+    *,
+    suffix: str,
+    http_do: HttpDo = _http_do,
+) -> bool:
+    """Upload current review state using process environment.
+
+    Missing Actions context or a transport failure is a no-op.
+
+    Args:
+        env: Process environment.
+        suffix: Artifact-name suffix (``inline``, ``ckpt-15``, ...).
+        http_do: Injectable HTTP client.
+
+    Returns:
+        True when an artifact was uploaded.
+    """
+    token = env.get("ACTIONS_RUNTIME_TOKEN", "").strip()
+    results_url = env.get("ACTIONS_RESULTS_URL", "").strip()
+    pr_number = _parse_optional_int(env.get("PR_NUMBER"))
+    if not token or not results_url or pr_number is None or pr_number <= 0:
+        return False
+    attempt = _parse_optional_int(env.get("GITHUB_RUN_ATTEMPT")) or 1
+    directory = Path(env.get("LINTRO_REVIEW_STATE_DIR") or DEFAULT_STATE_DIR)
+    try:
+        return upload_state(
+            directory=directory,
+            name=state_artifact_name(
+                pr_number=pr_number,
+                attempt=attempt,
+                suffix=suffix,
+            ),
+            token=token,
+            results_url=results_url,
+            http_do=http_do,
+        )
+    except Exception:  # noqa: BLE001 - fail-safe; never redden the review
+        return False
+
+
 def build_parser() -> argparse.ArgumentParser:
     """Build the CLI parser.
 
     Returns:
-        Parser for the ``locate`` subcommand.
+        Parser for the ``locate`` and ``upload`` subcommands.
     """
     parser = argparse.ArgumentParser(
-        description="Locate a prior AI-review state artifact run.",
+        description="Locate or upload an AI-review state artifact.",
     )
     subparsers = parser.add_subparsers(dest="command", required=True)
     subparsers.add_parser(
         "locate",
         help="Write run-id= for the latest eligible prior-state run.",
+    )
+    upload = subparsers.add_parser(
+        "upload",
+        help="Upload ai-review-state/ from inside the review step.",
+    )
+    upload.add_argument(
+        "--suffix",
+        default="inline",
+        help="Artifact-name suffix so a run can upload more than once.",
     )
     return parser
 
@@ -559,10 +887,17 @@ def main(argv: Sequence[str] | None = None) -> int:
         argv: Optional argument vector; ``None`` uses ``sys.argv``.
 
     Returns:
-        Always ``0``. Empty ``run-id=`` is the no-op / fail-safe result.
+        Always ``0``. Empty ``run-id=`` / failed upload is the fail-safe.
     """
     parser = build_parser()
-    parser.parse_args(argv)
+    args = parser.parse_args(argv)
+    if args.command == "upload":
+        uploaded = upload_from_env(os.environ, suffix=str(args.suffix))
+        if uploaded:
+            sys.stdout.write(
+                f"uploaded review-state artifact ({args.suffix})\n",
+            )
+        return 0
     output_raw = os.environ.get("GITHUB_OUTPUT", "").strip()
     output_path = Path(output_raw) if output_raw else None
     write_run_id(locate_from_env(os.environ), output_path)

--- a/scripts/ci/review_state_artifacts.py
+++ b/scripts/ci/review_state_artifacts.py
@@ -29,6 +29,7 @@ import re
 import shutil
 import subprocess  # nosec B404 - gh argv is built internally; shell=False
 import sys
+import time
 import urllib.error
 import urllib.request
 import zipfile
@@ -47,7 +48,13 @@ _STATE_NAME_RE: Final[re.Pattern[str]] = re.compile(
     rf"^{re.escape(STATE_ARTIFACT_PREFIX)}(\d+)-",
 )
 _GH_API_TIMEOUT_SECONDS: Final[int] = 30
-_UPLOAD_TIMEOUT_SECONDS: Final[int] = 8
+_UPLOAD_TIMEOUT_SECONDS: Final[float] = 8.0
+# Whole Create/PUT/Finalize after wait returns 143. GitHub's cancel
+# grace is ~7.5s; the log flush already used some of it. A 8s×3 upload
+# is SIGKILL'd and classify never runs (#2173).
+_CANCEL_UPLOAD_BUDGET_SECONDS: Final[float] = 2.0
+# Mid-run checkpoints happen while the job is healthy.
+_CHECKPOINT_UPLOAD_BUDGET_SECONDS: Final[float] = 24.0
 RUNS_PER_PAGE: Final[int] = 100
 ARTIFACTS_PER_PAGE: Final[int] = 100
 RETENTION_DAYS: Final[int] = 30
@@ -676,6 +683,8 @@ def _http_do(
     url: str,
     headers: Mapping[str, str],
     body: bytes,
+    *,
+    timeout: float = _UPLOAD_TIMEOUT_SECONDS,
 ) -> tuple[int, bytes]:
     """Issue one HTTPS request.
 
@@ -684,6 +693,7 @@ def _http_do(
         url: Absolute HTTPS URL.
         headers: Request headers.
         body: Request body; empty for no payload.
+        timeout: Connect+read deadline for this request.
 
     Returns:
         Status code and response body. HTTP errors are returned, not raised.
@@ -700,7 +710,7 @@ def _http_do(
     try:
         with urllib.request.urlopen(  # nosec B310 - https-only; URL from Actions
             request,
-            timeout=_UPLOAD_TIMEOUT_SECONDS,
+            timeout=max(0.05, timeout),
         ) as response:
             return int(response.status), response.read()
     except urllib.error.HTTPError as exc:
@@ -748,6 +758,44 @@ def _twirp_json(
     return decoded if isinstance(decoded, dict) else None
 
 
+def _bounded_http_do(
+    http_do: HttpDo,
+    *,
+    budget_seconds: float,
+) -> HttpDo:
+    """Stop starting requests once the whole-upload budget is gone.
+
+    Args:
+        http_do: Underlying client.
+        budget_seconds: Wall-clock budget for Create + PUT + Finalize.
+
+    Returns:
+        Client that returns ``(0, ...)`` when the deadline has passed.
+    """
+    deadline = time.monotonic() + max(0.0, budget_seconds)
+
+    def bounded(
+        method: str,
+        url: str,
+        headers: Mapping[str, str],
+        body: bytes,
+    ) -> tuple[int, bytes]:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            return 0, b"artifact upload budget exhausted"
+        if http_do is _http_do:
+            return _http_do(
+                method,
+                url,
+                headers,
+                body,
+                timeout=min(_UPLOAD_TIMEOUT_SECONDS, remaining),
+            )
+        return http_do(method, url, headers, body)
+
+    return bounded
+
+
 def upload_state(
     *,
     directory: Path,
@@ -755,6 +803,7 @@ def upload_state(
     token: str,
     results_url: str,
     http_do: HttpDo = _http_do,
+    budget_seconds: float = _CHECKPOINT_UPLOAD_BUDGET_SECONDS,
 ) -> bool:
     """Upload JSON state files as one Actions artifact.
 
@@ -764,6 +813,8 @@ def upload_state(
         token: ``ACTIONS_RUNTIME_TOKEN``.
         results_url: ``ACTIONS_RESULTS_URL``.
         http_do: Injectable HTTP client.
+        budget_seconds: Wall-clock cap for the whole Create/PUT/Finalize
+            walk. Cancel-path callers pass ``_CANCEL_UPLOAD_BUDGET_SECONDS``.
 
     Returns:
         True when Create + PUT + Finalize all succeeded.
@@ -775,6 +826,7 @@ def upload_state(
         return False
     archive = zip_state_files(files)
     digest = hashlib.sha256(archive).hexdigest()
+    client = _bounded_http_do(http_do, budget_seconds=budget_seconds)
     created = _twirp_json(
         origin=origin,
         method="CreateArtifact",
@@ -786,14 +838,14 @@ def upload_state(
             "version": 4,
             "mimeType": "application/zip",
         },
-        http_do=http_do,
+        http_do=client,
     )
-    if created is None or not created.get("ok", True):
+    if created is None or created.get("ok") is not True:
         return False
     signed = created.get("signedUploadUrl") or created.get("signed_upload_url")
     if not isinstance(signed, str) or not signed:
         return False
-    put_status, _put_body = http_do(
+    put_status, _put_body = client(
         "PUT",
         signed,
         {
@@ -817,9 +869,9 @@ def upload_state(
             "size": str(len(archive)),
             "hash": f"sha256:{digest}",
         },
-        http_do=http_do,
+        http_do=client,
     )
-    return bool(finalized is not None and finalized.get("ok", True))
+    return bool(finalized is not None and finalized.get("ok") is True)
 
 
 def upload_from_env(
@@ -827,6 +879,7 @@ def upload_from_env(
     *,
     suffix: str,
     http_do: HttpDo = _http_do,
+    budget_seconds: float | None = None,
 ) -> bool:
     """Upload current review state using process environment.
 
@@ -836,6 +889,8 @@ def upload_from_env(
         env: Process environment.
         suffix: Artifact-name suffix (``inline``, ``ckpt-15``, ...).
         http_do: Injectable HTTP client.
+        budget_seconds: Optional whole-upload cap. ``inline`` defaults to
+            the cancel-path budget; checkpoints use the longer default.
 
     Returns:
         True when an artifact was uploaded.
@@ -847,6 +902,12 @@ def upload_from_env(
         return False
     attempt = _parse_optional_int(env.get("GITHUB_RUN_ATTEMPT")) or 1
     directory = Path(env.get("LINTRO_REVIEW_STATE_DIR") or DEFAULT_STATE_DIR)
+    if budget_seconds is None:
+        budget_seconds = (
+            _CANCEL_UPLOAD_BUDGET_SECONDS
+            if suffix == "inline"
+            else _CHECKPOINT_UPLOAD_BUDGET_SECONDS
+        )
     try:
         return upload_state(
             directory=directory,
@@ -858,6 +919,7 @@ def upload_from_env(
             token=token,
             results_url=results_url,
             http_do=http_do,
+            budget_seconds=budget_seconds,
         )
     except Exception:  # noqa: BLE001 - fail-safe; never redden the review
         return False
@@ -886,6 +948,16 @@ def build_parser() -> argparse.ArgumentParser:
         default="inline",
         help="Artifact-name suffix so a run can upload more than once.",
     )
+    upload.add_argument(
+        "--budget-seconds",
+        type=float,
+        default=None,
+        help=(
+            "Wall-clock cap for Create/PUT/Finalize. inline defaults to "
+            f"{_CANCEL_UPLOAD_BUDGET_SECONDS:g}s so classify still runs "
+            "inside SIGTERM grace."
+        ),
+    )
     return parser
 
 
@@ -901,7 +973,11 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
     if args.command == "upload":
-        uploaded = upload_from_env(os.environ, suffix=str(args.suffix))
+        uploaded = upload_from_env(
+            os.environ,
+            suffix=str(args.suffix),
+            budget_seconds=args.budget_seconds,
+        )
         if uploaded:
             sys.stdout.write(
                 f"uploaded review-state artifact ({args.suffix})\n",

--- a/scripts/ci/review_state_artifacts.py
+++ b/scripts/ci/review_state_artifacts.py
@@ -708,7 +708,7 @@ def _http_do(
         headers=dict(headers),
     )
     try:
-        with urllib.request.urlopen(  # nosec B310 - https-only; URL from Actions
+        with urllib.request.urlopen(  # noqa: S310 — HTTPS-only validated above  # nosemgrep: dynamic-urllib-use-detected  # nosec B310
             request,
             timeout=max(0.05, timeout),
         ) as response:

--- a/scripts/ci/review_state_artifacts.py
+++ b/scripts/ci/review_state_artifacts.py
@@ -47,7 +47,7 @@ _STATE_NAME_RE: Final[re.Pattern[str]] = re.compile(
     rf"^{re.escape(STATE_ARTIFACT_PREFIX)}(\d+)-",
 )
 _GH_API_TIMEOUT_SECONDS: Final[int] = 30
-_UPLOAD_TIMEOUT_SECONDS: Final[int] = 15
+_UPLOAD_TIMEOUT_SECONDS: Final[int] = 8
 RUNS_PER_PAGE: Final[int] = 100
 ARTIFACTS_PER_PAGE: Final[int] = 100
 RETENTION_DAYS: Final[int] = 30
@@ -553,7 +553,11 @@ def locate_from_env(
 
 
 def state_files(directory: Path) -> list[Path]:
-    """Return JSON state files in ``directory``.
+    """Return JSON state files that are safe to merge across uploads.
+
+    Prefer ``part-*.json`` so ``download-artifact`` ``merge-multiple``
+    cannot overwrite ``state.json`` with an older checkpoint. Fall back
+    to ``state.json`` only when this run has not written a part yet.
 
     Args:
         directory: Review-state directory.
@@ -563,11 +567,15 @@ def state_files(directory: Path) -> list[Path]:
     """
     if not directory.is_dir():
         return []
-    return sorted(
+    parts = sorted(
         path
         for path in directory.iterdir()
-        if path.is_file() and path.suffix == ".json"
+        if path.is_file() and path.suffix == ".json" and path.name.startswith("part-")
     )
+    if parts:
+        return parts
+    snapshot = directory / "state.json"
+    return [snapshot] if snapshot.is_file() else []
 
 
 def sanitize_artifact_suffix(raw: str) -> str:
@@ -772,17 +780,17 @@ def upload_state(
         method="CreateArtifact",
         token=token,
         payload={
-            "workflow_run_backend_id": ids[0],
-            "workflow_job_run_backend_id": ids[1],
+            "workflowRunBackendId": ids[0],
+            "workflowJobRunBackendId": ids[1],
             "name": name,
             "version": 4,
-            "mime_type": {"value": "application/zip"},
+            "mimeType": "application/zip",
         },
         http_do=http_do,
     )
     if created is None or not created.get("ok", True):
         return False
-    signed = created.get("signed_upload_url") or created.get("signedUploadUrl")
+    signed = created.get("signedUploadUrl") or created.get("signed_upload_url")
     if not isinstance(signed, str) or not signed:
         return False
     put_status, _put_body = http_do(
@@ -792,6 +800,7 @@ def upload_state(
             "Content-Type": "application/zip",
             "x-ms-blob-type": "BlockBlob",
             "x-ms-blob-content-type": "application/zip",
+            "x-ms-version": "2023-11-03",
         },
         archive,
     )
@@ -802,11 +811,11 @@ def upload_state(
         method="FinalizeArtifact",
         token=token,
         payload={
-            "workflow_run_backend_id": ids[0],
-            "workflow_job_run_backend_id": ids[1],
+            "workflowRunBackendId": ids[0],
+            "workflowJobRunBackendId": ids[1],
             "name": name,
             "size": str(len(archive)),
-            "hash": {"value": f"sha256:{digest}"},
+            "hash": f"sha256:{digest}",
         },
         http_do=http_do,
     )
@@ -896,6 +905,10 @@ def main(argv: Sequence[str] | None = None) -> int:
         if uploaded:
             sys.stdout.write(
                 f"uploaded review-state artifact ({args.suffix})\n",
+            )
+        elif os.environ.get("GITHUB_ACTIONS") == "true":
+            sys.stderr.write(
+                f"review-state upload skipped or failed ({args.suffix})\n",
             )
         return 0
     output_raw = os.environ.get("GITHUB_OUTPUT", "").strip()

--- a/scripts/ci/run-ai-review.sh
+++ b/scripts/ci/run-ai-review.sh
@@ -162,10 +162,18 @@ mkdir -p "${LINTRO_REVIEW_STATE_DIR}"
 REVIEW_STATE_RUNTIME_TOKEN="${ACTIONS_RUNTIME_TOKEN:-}"
 REVIEW_STATE_RESULTS_URL="${ACTIONS_RESULTS_URL:-}"
 unset ACTIONS_RUNTIME_TOKEN ACTIONS_RESULTS_URL
+# Post-wait inline upload must finish inside GitHub's ~7.5s SIGTERM
+# grace so classify still runs. Mid-run checkpoints keep the longer cap.
+_CANCEL_UPLOAD_BUDGET_SECONDS=2
+_CHECKPOINT_UPLOAD_BUDGET_SECONDS=24
 _upload_review_state() {
-	ACTIONS_RUNTIME_TOKEN="${REVIEW_STATE_RUNTIME_TOKEN}" \
+	local suffix="$1"
+	local budget="${2:-$_CHECKPOINT_UPLOAD_BUDGET_SECONDS}"
+	timeout --signal=TERM --kill-after=1 "$budget" \
+		env ACTIONS_RUNTIME_TOKEN="${REVIEW_STATE_RUNTIME_TOKEN}" \
 		ACTIONS_RESULTS_URL="${REVIEW_STATE_RESULTS_URL}" \
-		python3 "${script_dir}/review_state_artifacts.py" upload --suffix "$1" || true
+		python3 "${script_dir}/review_state_artifacts.py" \
+		upload --suffix "$suffix" --budget-seconds "$budget" || true
 }
 
 # Heartbeat so a silent ``--output json`` review still proves the step is
@@ -180,7 +188,7 @@ _upload_review_state() {
 		mtime=$(stat -c %Y "${LINTRO_REVIEW_STATE_DIR}/state.json" 2>/dev/null || true)
 		if [[ -n "$mtime" && "$mtime" != "$last_mtime" ]]; then
 			last_mtime=$mtime
-			_upload_review_state "ckpt-${elapsed}"
+			_upload_review_state "ckpt-${elapsed}" "${_CHECKPOINT_UPLOAD_BUDGET_SECONDS}"
 		fi
 	done
 ) &
@@ -277,7 +285,8 @@ set -e
 
 # Upload before classify. GitHub cancels remaining always() steps after
 # SIGTERM; this call still has the persist snapshot on disk (#2166).
-_upload_review_state inline
+# Bound to 2s so a hung Create/PUT/Finalize cannot eat classify.
+_upload_review_state inline "${_CANCEL_UPLOAD_BUDGET_SECONDS}"
 
 # Exits 0 only when a review was produced; the classifier writes the annotation
 # and job summary either way. --transport names the failure vocabulary (#1923).

--- a/scripts/ci/run-ai-review.sh
+++ b/scripts/ci/run-ai-review.sh
@@ -65,7 +65,12 @@ set -euo pipefail
 #   LINTRO_AI_TRANSPORT     Optional overlay (workflow default: cli).
 #   LINTRO_REVIEW_STATE_DIR Directory for coverage artifacts (default:
 #                           ai-review-state). The workflow downloads prior
-#                           state here and uploads it after the review.
+#                           state here. This script uploads checkpoints
+#                           and an inline snapshot so a cancelled job
+#                           still leaves a resume artifact.
+#   ACTIONS_RUNTIME_TOKEN   Present in Actions; required for in-step upload.
+#   ACTIONS_RESULTS_URL     Actions artifact service origin for in-step upload.
+#   GITHUB_RUN_ATTEMPT      Distinguishes artifact names across retries.
 #   GITHUB_STEP_SUMMARY     When set, the outcome is appended as Markdown.
 
 if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
@@ -136,16 +141,6 @@ if [[ -z "$pr_number" ]]; then
 fi
 
 echo "Running AI review on PR #${pr_number} (posts comment)..."
-# Heartbeat so a silent ``--output json`` review still proves the step is
-# alive if the runner SIGTERM's it. Short sleeps so EXIT can reap quickly.
-(
-	elapsed=0
-	while sleep 15; do
-		elapsed=$((elapsed + 15))
-		printf '[ai-review] still running (%ss)\n' "${elapsed}"
-	done
-) &
-heartbeat_pid=$!
 
 # `--post` maintains the sticky review comment (and inline findings) on the PR.
 # It needs GITHUB_TOKEN (write) and the repo; the diff is still fetched via `gh`.
@@ -155,9 +150,34 @@ if [[ -n "${GITHUB_REPOSITORY:-}" ]]; then
 fi
 
 # Resume coverage is read from (and written to) this directory. The workflow
-# downloads a prior run's artifact here and uploads the directory afterwards.
+# downloads a prior run's artifact here. Incremental in-step uploads attach
+# checkpoints so a cancelled job (which skips later always() steps) still
+# leaves a resume artifact for the next round (#2166).
 export LINTRO_REVIEW_STATE_DIR="${LINTRO_REVIEW_STATE_DIR:-ai-review-state}"
 mkdir -p "${LINTRO_REVIEW_STATE_DIR}"
+
+# Best-effort: never redden the review because an artifact upload failed.
+_upload_review_state() {
+	python3 "${script_dir}/review_state_artifacts.py" upload --suffix "$1" || true
+}
+
+# Heartbeat so a silent ``--output json`` review still proves the step is
+# alive if the runner SIGTERM's it. Short sleeps so EXIT can reap quickly.
+# When state.json changes, upload a checkpoint before the next SIGTERM.
+(
+	elapsed=0
+	last_mtime=""
+	while sleep 15; do
+		elapsed=$((elapsed + 15))
+		printf '[ai-review] still running (%ss)\n' "${elapsed}"
+		mtime=$(stat -c %Y "${LINTRO_REVIEW_STATE_DIR}/state.json" 2>/dev/null || true)
+		if [[ -n "$mtime" && "$mtime" != "$last_mtime" ]]; then
+			last_mtime=$mtime
+			_upload_review_state "ckpt-${elapsed}"
+		fi
+	done
+) &
+heartbeat_pid=$!
 
 # Tee to a file: the classifier needs the JSON error envelope, and the live
 # stream must still reach the Actions log so a mid-run SIGTERM is diagnosable.
@@ -247,6 +267,10 @@ kill -KILL "${log_pid:-}" 2>/dev/null || true
 wait "${log_pid:-}" 2>/dev/null || true
 trap - TERM INT
 set -e
+
+# Upload before classify. GitHub cancels remaining always() steps after
+# SIGTERM; this call still has the persist snapshot on disk (#2166).
+_upload_review_state inline
 
 # Exits 0 only when a review was produced; the classifier writes the annotation
 # and job summary either way. --transport names the failure vocabulary (#1923).

--- a/scripts/ci/run-ai-review.sh
+++ b/scripts/ci/run-ai-review.sh
@@ -157,8 +157,15 @@ export LINTRO_REVIEW_STATE_DIR="${LINTRO_REVIEW_STATE_DIR:-ai-review-state}"
 mkdir -p "${LINTRO_REVIEW_STATE_DIR}"
 
 # Best-effort: never redden the review because an artifact upload failed.
+# Keep the runtime token out of the agent CLI environment — lintro copies
+# os.environ into the provider subprocess.
+REVIEW_STATE_RUNTIME_TOKEN="${ACTIONS_RUNTIME_TOKEN:-}"
+REVIEW_STATE_RESULTS_URL="${ACTIONS_RESULTS_URL:-}"
+unset ACTIONS_RUNTIME_TOKEN ACTIONS_RESULTS_URL
 _upload_review_state() {
-	python3 "${script_dir}/review_state_artifacts.py" upload --suffix "$1" || true
+	ACTIONS_RUNTIME_TOKEN="${REVIEW_STATE_RUNTIME_TOKEN}" \
+		ACTIONS_RESULTS_URL="${REVIEW_STATE_RESULTS_URL}" \
+		python3 "${script_dir}/review_state_artifacts.py" upload --suffix "$1" || true
 }
 
 # Heartbeat so a silent ``--output json`` review still proves the step is

--- a/tests/scripts/test_classify_review_outcome.py
+++ b/tests/scripts/test_classify_review_outcome.py
@@ -98,9 +98,16 @@ def test_clean_review_passes(classifier: ModuleType) -> None:
     assert_that(report.transport).is_equal_to("cli")
 
 
-def test_incomplete_coverage_reddens_the_check(classifier: ModuleType) -> None:
-    """A produced review with incomplete coverage must fail the check (#2154)."""
-    output = json.dumps(
+def _incomplete_envelope(*, stopped_reason: str = "cost cap") -> str:
+    """Return a persist JSON envelope with incomplete coverage.
+
+    Args:
+        stopped_reason: Why the review stopped early.
+
+    Returns:
+        Captured-output text containing the coverage envelope.
+    """
+    return json.dumps(
         {
             "readiness_verdict": "incomplete",
             "coverage": {
@@ -112,14 +119,60 @@ def test_incomplete_coverage_reddens_the_check(classifier: ModuleType) -> None:
                 "covered_at_head": 2,
                 "complete": False,
             },
-            "stopped_reason": "cost cap",
+            "stopped_reason": stopped_reason,
+            "partial": True,
         },
     )
-    report = classifier.classify(status=0, output=output)
+
+
+def test_incomplete_coverage_reddens_the_check(classifier: ModuleType) -> None:
+    """A produced review with incomplete coverage must fail the check (#2154)."""
+    report = classifier.classify(status=0, output=_incomplete_envelope())
 
     assert_that(report.outcome).is_equal_to(classifier.ReviewOutcome.INCOMPLETE)
     assert_that(report.exit_code).is_equal_to(1)
     assert_that(report.headline).contains("2/7 files covered at HEAD")
+
+
+def test_sigterm_status_with_persist_envelope_is_incomplete(
+    classifier: ModuleType,
+) -> None:
+    """``wait`` 143 after a SIGTERM persist must not read as unexpected (#2166)."""
+    report = classifier.classify(
+        status=classifier.SIGTERM_STATUS,
+        output=_incomplete_envelope(stopped_reason="timeout (SIGTERM)"),
+    )
+
+    assert_that(report.outcome).is_equal_to(classifier.ReviewOutcome.INCOMPLETE)
+    assert_that(report.exit_code).is_equal_to(1)
+    assert_that(report.headline).contains("2/7 files covered at HEAD")
+    assert_that(report.headline).does_not_contain("unexpected status")
+    assert_that(report.detail).contains("SIGTERM")
+
+
+def test_sigterm_status_with_complete_envelope_is_reviewed(
+    classifier: ModuleType,
+) -> None:
+    """A finished envelope must stay REVIEWED when wait reports SIGTERM."""
+    output = json.dumps(
+        {
+            "readiness_verdict": "ready",
+            "coverage": {
+                "reviewed": 3,
+                "carried": 0,
+                "awaiting": 0,
+                "invalidated": 0,
+                "eligible": 3,
+                "covered_at_head": 3,
+                "complete": True,
+            },
+        },
+    )
+    report = classifier.classify(status=classifier.SIGTERM_STATUS, output=output)
+
+    assert_that(report.outcome).is_equal_to(classifier.ReviewOutcome.REVIEWED)
+    assert_that(report.exit_code).is_equal_to(0)
+    assert_that(report.headline).does_not_contain("unexpected status")
 
 
 def test_review_with_findings_still_passes(classifier: ModuleType) -> None:

--- a/tests/scripts/test_classify_review_outcome.py
+++ b/tests/scripts/test_classify_review_outcome.py
@@ -186,6 +186,32 @@ def test_sigterm_status_with_complete_envelope_is_reviewed(
     assert_that(report.outcome).is_equal_to(classifier.ReviewOutcome.REVIEWED)
     assert_that(report.exit_code).is_equal_to(0)
     assert_that(report.headline).does_not_contain("unexpected status")
+    assert_that(report.headline).contains("no P1 findings")
+
+
+def test_sigterm_status_with_complete_p1_envelope_names_findings(
+    classifier: ModuleType,
+) -> None:
+    """A finished P1 envelope must not be labelled clean after SIGTERM."""
+    output = json.dumps(
+        {
+            "readiness_verdict": "ready",
+            "coverage": {
+                "reviewed": 3,
+                "carried": 0,
+                "awaiting": 0,
+                "invalidated": 0,
+                "eligible": 3,
+                "covered_at_head": 3,
+                "complete": True,
+            },
+            "findings": [{"severity": "P1", "title": "bug"}],
+        },
+    )
+    report = classifier.classify(status=classifier.SIGTERM_STATUS, output=output)
+
+    assert_that(report.outcome).is_equal_to(classifier.ReviewOutcome.REVIEWED)
+    assert_that(report.headline).contains("P1 findings posted")
 
 
 def test_review_with_findings_still_passes(classifier: ModuleType) -> None:

--- a/tests/scripts/test_classify_review_outcome.py
+++ b/tests/scripts/test_classify_review_outcome.py
@@ -150,6 +150,19 @@ def test_sigterm_status_with_persist_envelope_is_incomplete(
     assert_that(report.detail).contains("SIGTERM")
 
 
+def test_error_status_with_persist_envelope_is_incomplete(
+    classifier: ModuleType,
+) -> None:
+    """A persist envelope beats an error status so resume is not discarded."""
+    report = classifier.classify(
+        status=classifier.REVIEW_STATUS_ERROR,
+        output=_incomplete_envelope(stopped_reason="timeout (SIGTERM)"),
+    )
+
+    assert_that(report.outcome).is_equal_to(classifier.ReviewOutcome.INCOMPLETE)
+    assert_that(report.headline).does_not_contain("nothing was reviewed")
+
+
 def test_sigterm_status_with_complete_envelope_is_reviewed(
     classifier: ModuleType,
 ) -> None:

--- a/tests/scripts/test_review_state_artifacts.py
+++ b/tests/scripts/test_review_state_artifacts.py
@@ -7,6 +7,7 @@ import importlib.util
 import json
 import re
 import sys
+import time
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from types import ModuleType
@@ -728,6 +729,37 @@ def test_upload_rejects_untrusted_results_host(
     assert_that(calls).is_empty()
 
 
+def _state_env(
+    tmp_path: Path,
+    *,
+    with_part: bool = True,
+) -> tuple[Path, dict[str, str]]:
+    """Create a state directory and the Actions env the uploader reads.
+
+    Args:
+        tmp_path: Pytest temp directory.
+        with_part: When True, include a ``part-*.json`` file.
+
+    Returns:
+        State directory and environment mapping.
+    """
+    state_dir = tmp_path / "ai-review-state"
+    state_dir.mkdir()
+    (state_dir / "state.json").write_text('{"schema_version": 3}\n', encoding="utf-8")
+    if with_part:
+        (state_dir / "part-0001.json").write_text(
+            '{"schema_version": 3, "coverage": []}\n',
+            encoding="utf-8",
+        )
+    return state_dir, {
+        "ACTIONS_RUNTIME_TOKEN": _runtime_jwt(),
+        "ACTIONS_RESULTS_URL": "https://results-receiver.actions.githubusercontent.com/",
+        "PR_NUMBER": "2166",
+        "GITHUB_RUN_ATTEMPT": "3",
+        "LINTRO_REVIEW_STATE_DIR": str(state_dir),
+    }
+
+
 def test_main_upload_never_exits_nonzero(
     artifacts: ModuleType,
     monkeypatch: pytest.MonkeyPatch,
@@ -737,3 +769,128 @@ def test_main_upload_never_exits_nonzero(
     monkeypatch.delenv("ACTIONS_RESULTS_URL", raising=False)
     monkeypatch.setenv("PR_NUMBER", "2166")
     assert_that(artifacts.main(["upload", "--suffix", "inline"])).is_equal_to(0)
+
+
+def test_upload_budget_zero_makes_no_http_calls(
+    artifacts: ModuleType,
+    tmp_path: Path,
+) -> None:
+    """A spent budget must not start Create/PUT/Finalize."""
+    _state_dir, env = _state_env(tmp_path)
+    calls: list[str] = []
+
+    def http_do(
+        method: str,
+        url: str,
+        _headers: dict[str, str],
+        _body: bytes,
+    ) -> tuple[int, bytes]:
+        calls.append(f"{method} {url}")
+        return 200, b'{"ok":true}'
+
+    uploaded = artifacts.upload_from_env(
+        env,
+        suffix="inline",
+        http_do=http_do,
+        budget_seconds=0,
+    )
+    assert_that(uploaded).is_false()
+    assert_that(calls).is_empty()
+
+
+def test_upload_budget_stops_after_the_first_slow_request(
+    artifacts: ModuleType,
+    tmp_path: Path,
+) -> None:
+    """A request that consumes the budget must skip PUT and Finalize."""
+    _state_dir, env = _state_env(tmp_path)
+    calls: list[str] = []
+
+    def http_do(
+        method: str,
+        url: str,
+        _headers: dict[str, str],
+        _body: bytes,
+    ) -> tuple[int, bytes]:
+        calls.append(url.rsplit("/", 1)[-1] if method != "PUT" else "PUT")
+        time.sleep(0.05)
+        if url.endswith("/CreateArtifact"):
+            return 200, b'{"ok":true,"signedUploadUrl":"https://blob.example/upload"}'
+        return 200, b'{"ok":true}'
+
+    uploaded = artifacts.upload_from_env(
+        env,
+        suffix="inline",
+        http_do=http_do,
+        budget_seconds=0.02,
+    )
+    assert_that(uploaded).is_false()
+    assert_that(calls).is_equal_to(["CreateArtifact"])
+
+
+def test_upload_from_env_fails_closed_on_http_errors(
+    artifacts: ModuleType,
+    tmp_path: Path,
+) -> None:
+    """Create 500, ok:false, PUT 4xx, and omitted Finalize ok are not success."""
+    _state_dir, env = _state_env(tmp_path)
+
+    def create_500(
+        _method: str,
+        _url: str,
+        _headers: dict[str, str],
+        _body: bytes,
+    ) -> tuple[int, bytes]:
+        return 500, b"nope"
+
+    def ok_false(
+        _method: str,
+        url: str,
+        _headers: dict[str, str],
+        _body: bytes,
+    ) -> tuple[int, bytes]:
+        if url.endswith("/CreateArtifact"):
+            return 200, b'{"ok":false}'
+        return 200, b"{}"
+
+    def put_403(
+        _method: str,
+        url: str,
+        _headers: dict[str, str],
+        _body: bytes,
+    ) -> tuple[int, bytes]:
+        if url.endswith("/CreateArtifact"):
+            return 200, b'{"ok":true,"signedUploadUrl":"https://blob.example/upload"}'
+        if url == "https://blob.example/upload":
+            return 403, b"blocked"
+        return 200, b'{"ok":true}'
+
+    def finalize_omits_ok(
+        _method: str,
+        url: str,
+        _headers: dict[str, str],
+        _body: bytes,
+    ) -> tuple[int, bytes]:
+        if url.endswith("/CreateArtifact"):
+            return 200, b'{"ok":true,"signedUploadUrl":"https://blob.example/upload"}'
+        if url == "https://blob.example/upload":
+            return 201, b""
+        return 200, b'{"artifactId":"9"}'
+
+    for http_do in (create_500, ok_false, put_403, finalize_omits_ok):
+        assert_that(
+            artifacts.upload_from_env(env, suffix="inline", http_do=http_do),
+        ).is_false()
+
+
+def test_inline_suffix_uses_the_cancel_budget_by_default(
+    artifacts: ModuleType,
+) -> None:
+    """Post-wait uploads default to 2s so classify still fits in SIGTERM grace."""
+    assert_that(artifacts._CANCEL_UPLOAD_BUDGET_SECONDS).is_equal_to(2.0)
+    assert_that(artifacts._CANCEL_UPLOAD_BUDGET_SECONDS).is_less_than(
+        artifacts._UPLOAD_TIMEOUT_SECONDS,
+    )
+    assert_that(artifacts._CHECKPOINT_UPLOAD_BUDGET_SECONDS).is_greater_than(
+        artifacts._CANCEL_UPLOAD_BUDGET_SECONDS,
+    )

--- a/tests/scripts/test_review_state_artifacts.py
+++ b/tests/scripts/test_review_state_artifacts.py
@@ -626,6 +626,10 @@ def test_upload_state_creates_puts_and_finalizes(
     state_dir = tmp_path / "ai-review-state"
     state_dir.mkdir()
     (state_dir / "state.json").write_text('{"schema_version": 3}\n', encoding="utf-8")
+    (state_dir / "part-0001.json").write_text(
+        '{"schema_version": 3, "coverage": []}\n',
+        encoding="utf-8",
+    )
     calls: list[tuple[str, str]] = []
 
     def http_do(
@@ -639,21 +643,24 @@ def test_upload_state_creates_puts_and_finalizes(
             assert_that(headers["Authorization"]).starts_with("Bearer ")
             payload = json.loads(body.decode("utf-8"))
             assert_that(payload["name"]).contains("lintro-review-state-pr-2166-")
-            assert_that(payload["workflow_run_backend_id"]).is_equal_to("run-backend")
+            assert_that(payload["workflowRunBackendId"]).is_equal_to("run-backend")
+            assert_that(payload["mimeType"]).is_equal_to("application/zip")
             return (
                 200,
-                b'{"ok":true,"signed_upload_url":"https://blob.example/upload"}',
+                b'{"ok":true,"signedUploadUrl":"https://blob.example/upload"}',
             )
         if url == "https://blob.example/upload":
             assert_that(method).is_equal_to("PUT")
             assert_that(headers["x-ms-blob-type"]).is_equal_to("BlockBlob")
-            assert_that(body).contains(b"state.json")
+            assert_that(headers["x-ms-version"]).is_equal_to("2023-11-03")
+            assert_that(body).contains(b"part-0001.json")
+            assert_that(body).does_not_contain(b"state.json")
             return 201, b""
         if url.endswith("/FinalizeArtifact"):
             payload = json.loads(body.decode("utf-8"))
             assert_that(payload["size"]).is_not_equal_to("0")
-            assert_that(payload["hash"]["value"]).starts_with("sha256:")
-            return 200, b'{"ok":true,"artifact_id":"9"}'
+            assert_that(payload["hash"]).starts_with("sha256:")
+            return 200, b'{"ok":true,"artifactId":"9"}'
         return 500, b"unexpected"
 
     uploaded = artifacts.upload_from_env(

--- a/tests/scripts/test_review_state_artifacts.py
+++ b/tests/scripts/test_review_state_artifacts.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import base64
 import importlib.util
+import json
 import re
 import sys
 from datetime import UTC, datetime, timedelta
@@ -584,3 +586,143 @@ def test_main_writes_empty_run_id_without_github(
     monkeypatch.setenv("GITHUB_OUTPUT", str(output))
     assert_that(artifacts.main(["locate"])).is_equal_to(0)
     assert_that(output.read_text(encoding="utf-8")).is_equal_to("run-id=\n")
+
+
+def _runtime_jwt() -> str:
+    """Build a runtime JWT whose scp claim carries Results backend IDs.
+
+    Returns:
+        Three-part JWT string.
+    """
+    header = base64.urlsafe_b64encode(b'{"alg":"none"}').rstrip(b"=").decode("ascii")
+    payload = (
+        base64.urlsafe_b64encode(
+            b'{"scp":"Actions.Example Actions.Results:run-backend:job-backend"}',
+        )
+        .rstrip(b"=")
+        .decode("ascii")
+    )
+    return f"{header}.{payload}.sig"
+
+
+def test_state_artifact_name_keeps_the_pr_prefix(artifacts: ModuleType) -> None:
+    """In-step uploads must still match the locator/download prefix."""
+    name = artifacts.state_artifact_name(pr_number=2166, attempt=2, suffix="inline")
+    assert_that(name).is_equal_to("lintro-review-state-pr-2166-attempt-2-inline")
+    assert_that(artifacts.is_state_artifact_for_pr(name, 2166)).is_true()
+    dirty = artifacts.state_artifact_name(
+        pr_number=2166,
+        attempt=1,
+        suffix="ckpt 15/../x",
+    )
+    assert_that(dirty).is_equal_to("lintro-review-state-pr-2166-attempt-1-ckpt-15-x")
+
+
+def test_upload_state_creates_puts_and_finalizes(
+    artifacts: ModuleType,
+    tmp_path: Path,
+) -> None:
+    """The in-step uploader walks CreateArtifact, blob PUT, FinalizeArtifact."""
+    state_dir = tmp_path / "ai-review-state"
+    state_dir.mkdir()
+    (state_dir / "state.json").write_text('{"schema_version": 3}\n', encoding="utf-8")
+    calls: list[tuple[str, str]] = []
+
+    def http_do(
+        method: str,
+        url: str,
+        headers: dict[str, str],
+        body: bytes,
+    ) -> tuple[int, bytes]:
+        calls.append((method, url))
+        if url.endswith("/CreateArtifact"):
+            assert_that(headers["Authorization"]).starts_with("Bearer ")
+            payload = json.loads(body.decode("utf-8"))
+            assert_that(payload["name"]).contains("lintro-review-state-pr-2166-")
+            assert_that(payload["workflow_run_backend_id"]).is_equal_to("run-backend")
+            return (
+                200,
+                b'{"ok":true,"signed_upload_url":"https://blob.example/upload"}',
+            )
+        if url == "https://blob.example/upload":
+            assert_that(method).is_equal_to("PUT")
+            assert_that(headers["x-ms-blob-type"]).is_equal_to("BlockBlob")
+            assert_that(body).contains(b"state.json")
+            return 201, b""
+        if url.endswith("/FinalizeArtifact"):
+            payload = json.loads(body.decode("utf-8"))
+            assert_that(payload["size"]).is_not_equal_to("0")
+            assert_that(payload["hash"]["value"]).starts_with("sha256:")
+            return 200, b'{"ok":true,"artifact_id":"9"}'
+        return 500, b"unexpected"
+
+    uploaded = artifacts.upload_from_env(
+        {
+            "ACTIONS_RUNTIME_TOKEN": _runtime_jwt(),
+            "ACTIONS_RESULTS_URL": "https://results-receiver.actions.githubusercontent.com/",
+            "PR_NUMBER": "2166",
+            "GITHUB_RUN_ATTEMPT": "3",
+            "LINTRO_REVIEW_STATE_DIR": str(state_dir),
+        },
+        suffix="inline",
+        http_do=http_do,
+    )
+    assert_that(uploaded).is_true()
+    assert_that(calls).is_length(3)
+    assert_that(calls[0][1]).contains("CreateArtifact")
+    assert_that(calls[1][0]).is_equal_to("PUT")
+    assert_that(calls[2][1]).contains("FinalizeArtifact")
+
+
+def test_upload_from_env_is_fail_safe_without_runtime_token(
+    artifacts: ModuleType,
+    tmp_path: Path,
+) -> None:
+    """Local or pre-token runs must no-op instead of failing the review."""
+    state_dir = tmp_path / "ai-review-state"
+    state_dir.mkdir()
+    (state_dir / "state.json").write_text("{}", encoding="utf-8")
+    uploaded = artifacts.upload_from_env(
+        {
+            "PR_NUMBER": "2166",
+            "LINTRO_REVIEW_STATE_DIR": str(state_dir),
+        },
+        suffix="inline",
+    )
+    assert_that(uploaded).is_false()
+
+
+def test_upload_rejects_untrusted_results_host(
+    artifacts: ModuleType,
+    tmp_path: Path,
+) -> None:
+    """The Twirp client must not follow an arbitrary RESULTS_URL."""
+    state_dir = tmp_path / "ai-review-state"
+    state_dir.mkdir()
+    (state_dir / "state.json").write_text("{}", encoding="utf-8")
+
+    def http_do(*_args: object) -> tuple[int, bytes]:
+        raise AssertionError("must not contact an untrusted host")
+
+    uploaded = artifacts.upload_from_env(
+        {
+            "ACTIONS_RUNTIME_TOKEN": _runtime_jwt(),
+            "ACTIONS_RESULTS_URL": "https://evil.example/",
+            "PR_NUMBER": "2166",
+            "LINTRO_REVIEW_STATE_DIR": str(state_dir),
+        },
+        suffix="inline",
+        http_do=http_do,
+    )
+    assert_that(uploaded).is_false()
+
+
+def test_main_upload_never_exits_nonzero(
+    artifacts: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The upload CLI is fail-safe even when nothing can be uploaded."""
+    monkeypatch.delenv("ACTIONS_RUNTIME_TOKEN", raising=False)
+    monkeypatch.delenv("ACTIONS_RESULTS_URL", raising=False)
+    monkeypatch.setenv("PR_NUMBER", "2166")
+    assert_that(artifacts.main(["upload", "--suffix", "inline"])).is_equal_to(0)

--- a/tests/scripts/test_review_state_artifacts.py
+++ b/tests/scripts/test_review_state_artifacts.py
@@ -708,8 +708,11 @@ def test_upload_rejects_untrusted_results_host(
     state_dir.mkdir()
     (state_dir / "state.json").write_text("{}", encoding="utf-8")
 
-    def http_do(*_args: object) -> tuple[int, bytes]:
-        raise AssertionError("must not contact an untrusted host")
+    calls: list[tuple[object, ...]] = []
+
+    def http_do(*args: object) -> tuple[int, bytes]:
+        calls.append(args)
+        return 200, b"{}"
 
     uploaded = artifacts.upload_from_env(
         {
@@ -722,6 +725,7 @@ def test_upload_rejects_untrusted_results_host(
         http_do=http_do,
     )
     assert_that(uploaded).is_false()
+    assert_that(calls).is_empty()
 
 
 def test_main_upload_never_exits_nonzero(

--- a/tests/scripts/test_run_ai_review.py
+++ b/tests/scripts/test_run_ai_review.py
@@ -1022,6 +1022,10 @@ def test_run_ai_review_tees_under_pipefail() -> None:
     assert_that(shell_text).contains('upload --suffix "$1"')
     assert_that(shell_text).contains("_upload_review_state inline")
     assert_that(shell_text).contains("ckpt-${elapsed}")
+    assert_that(shell_text).contains("unset ACTIONS_RUNTIME_TOKEN ACTIONS_RESULTS_URL")
+    assert_that(shell_text).contains(
+        'ACTIONS_RUNTIME_TOKEN="${REVIEW_STATE_RUNTIME_TOKEN}"'
+    )
     result = subprocess.run(  # nosec B603 B607 - fixed bash argv in a controlled test; binary name resolved from PATH, not attacker-controlled; shell=False
         [
             "bash",

--- a/tests/scripts/test_run_ai_review.py
+++ b/tests/scripts/test_run_ai_review.py
@@ -1019,12 +1019,22 @@ def test_run_ai_review_tees_under_pipefail() -> None:
     assert_that(shell_text).contains("[ai-review] still running")
     assert_that(shell_text).contains("persist-on-SIGTERM enabled")
     assert_that(shell_text).contains("review_state_artifacts.py")
-    assert_that(shell_text).contains('upload --suffix "$1"')
-    assert_that(shell_text).contains("_upload_review_state inline")
+    assert_that(shell_text).contains(
+        'upload --suffix "$suffix" --budget-seconds "$budget"',
+    )
+    assert_that(shell_text).contains("timeout --signal=TERM --kill-after=1")
+    assert_that(shell_text).contains("_CANCEL_UPLOAD_BUDGET_SECONDS=2")
+    assert_that(shell_text).contains(
+        '_upload_review_state inline "${_CANCEL_UPLOAD_BUDGET_SECONDS}"',
+    )
+    inline_call = '_upload_review_state inline "${_CANCEL_UPLOAD_BUDGET_SECONDS}"'
+    assert_that(shell_text.index(inline_call)).is_less_than(
+        shell_text.rindex("classify_review_outcome.py"),
+    )
     assert_that(shell_text).contains("ckpt-${elapsed}")
     assert_that(shell_text).contains("unset ACTIONS_RUNTIME_TOKEN ACTIONS_RESULTS_URL")
     assert_that(shell_text).contains(
-        'ACTIONS_RUNTIME_TOKEN="${REVIEW_STATE_RUNTIME_TOKEN}"'
+        'ACTIONS_RUNTIME_TOKEN="${REVIEW_STATE_RUNTIME_TOKEN}"',
     )
     result = subprocess.run(  # nosec B603 B607 - fixed bash argv in a controlled test; binary name resolved from PATH, not attacker-controlled; shell=False
         [

--- a/tests/scripts/test_run_ai_review.py
+++ b/tests/scripts/test_run_ai_review.py
@@ -764,6 +764,7 @@ def test_workflow_reviews_pr_via_gh_not_working_tree() -> None:
         "actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1",
         "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c",
         "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a",
+        "actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd",
     ],
 )
 def test_workflow_pins_actions_to_sha(*, action_ref: str) -> None:
@@ -1224,7 +1225,30 @@ def test_workflow_keeps_mint_immediately_before_review() -> None:
     upload_index = names.index("Upload review-state artifacts")
     locate_index = names.index("Locate prior review-state run")
     download_index = names.index("Download prior review-state artifacts")
+    runtime_index = names.index("Expose Actions runtime for state upload")
     assert_that(review_index).is_equal_to(mint_index + 1)
     assert_that(locate_index).is_less_than(mint_index)
     assert_that(download_index).is_less_than(mint_index)
+    assert_that(runtime_index).is_less_than(mint_index)
     assert_that(upload_index).is_greater_than(review_index)
+
+
+def test_workflow_exports_runtime_token_into_review_step() -> None:
+    """In-step upload needs the runtime token that ``run:`` steps lack."""
+    steps = _ai_review_steps()
+    runtime = next(
+        step
+        for step in steps
+        if step.get("name") == "Expose Actions runtime for state upload"
+    )
+    assert_that(runtime["id"]).is_equal_to("artifact-runtime")
+    assert_that(str(runtime["uses"])).starts_with("actions/github-script@")
+    review = next(
+        step for step in steps if str(step.get("name", "")).startswith("Run AI review")
+    )
+    assert_that(review["env"]["ACTIONS_RUNTIME_TOKEN"]).is_equal_to(
+        "${{ steps.artifact-runtime.outputs.runtime-token }}",
+    )
+    assert_that(review["env"]["ACTIONS_RESULTS_URL"]).is_equal_to(
+        "${{ steps.artifact-runtime.outputs.results-url }}",
+    )

--- a/tests/scripts/test_run_ai_review.py
+++ b/tests/scripts/test_run_ai_review.py
@@ -977,6 +977,7 @@ def test_workflow_allows_the_npm_registry_egress() -> None:
         "nodejs.org:443",
         "release-assets.githubusercontent.com:443",
         "pipelines.actions.githubusercontent.com:443",
+        "results-receiver.actions.githubusercontent.com:443",
     )
     for endpoint in endpoints:
         assert_that(endpoint).described_as(endpoint).does_not_contain("*")
@@ -1016,6 +1017,10 @@ def test_run_ai_review_tees_under_pipefail() -> None:
     assert_that(shell_text).contains("sleep 0.5")
     assert_that(shell_text).contains("[ai-review] still running")
     assert_that(shell_text).contains("persist-on-SIGTERM enabled")
+    assert_that(shell_text).contains("review_state_artifacts.py")
+    assert_that(shell_text).contains('upload --suffix "$1"')
+    assert_that(shell_text).contains("_upload_review_state inline")
+    assert_that(shell_text).contains("ckpt-${elapsed}")
     result = subprocess.run(  # nosec B603 B607 - fixed bash argv in a controlled test; binary name resolved from PATH, not attacker-controlled; shell=False
         [
             "bash",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(ci): persist review-state across runner cancel
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What’s Changing

#2166 round 5 persisted 3/14 chunks on SIGTERM (`68a9f42c`) but the next run still started empty:

1. The classifier treated `wait` status 143 as **unexpected**, even though lintro had already written an INCOMPLETE envelope.
2. GitHub then cancelled the job (`The operation was canceled`) and skipped the later `if: always()` upload. Incremental `state.json` died with the runner.

This PR:

- Classifies a persist envelope (incomplete coverage) as **INCOMPLETE** regardless of wrapper status, including 143
- Exports `ACTIONS_RUNTIME_TOKEN` / `ACTIONS_RESULTS_URL` from a pinned `actions/github-script` step (`run:` steps do not receive them)
- Unsets those vars before `lintro review` so the agent CLI does not inherit artifact-write credentials
- Uploads `part-*.json` checkpoints from inside `run-ai-review.sh` when `state.json` changes, plus an inline snapshot after persist
- Uses proto3 JSON (camelCase + bare `StringValue` strings) against the Actions artifact Twirp API
- Keeps the existing `always()` final upload for clean / step-timeout finishes
- Allowlists `results-receiver.actions.githubusercontent.com` for the in-step Twirp client

Do **not** merge #2165/#2166 as terraform/SPDX. After this lands, merge `origin/main` into `cursor/2156-step5-14chunk` so `base.sha` installs the cancel-safe upload, then record artifact + quiet resume.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [x] Docs updated if user-facing
- [x] Local tests passed (`test_classify_review_outcome`, `test_review_state_artifacts`, `test_run_ai_review`: 127 passed)

## Related Issues

Related #2156
Related #2166
Related #2171

## Details

Live evidence (persist fired, upload skipped):

- https://github.com/lgtm-hq/py-lintro/actions/runs/32809752800
- Review 04:41:24Z–04:57:28Z (~964s), persist 3/14, classifier `unexpected status 143`, upload skipped

**Fable:** request changes on `0f5d1a8d` (P1 Twirp wrapper objects; P2 `state.json` merge). Comment on `aaf265c2` after those landed. Remaining P2 (token inherited by agent CLI) fixed in `44a5d978`. Residual: first live run must confirm the signed PUT host is not blocked.

**Sol:** request changes on `0f5d1a8d` and `aaf265c2` for the blob-host allowlist. Official `upload-artifact` already succeeds on this job without a blob wildcard; the in-step PUT uses the same signed URL. Fail-safe skip is logged. Do not add `*.blob.core.windows.net`.

Local verification: 127 passed on classifier + artifact helper + run-ai-review wiring.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0ff3c26c-cf67-4c32-bff9-30643bc047b9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0ff3c26c-cf67-4c32-bff9-30643bc047b9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Review progress checkpoints and state artifacts are uploaded during active reviews.
  * Interrupted reviews can resume with previously persisted coverage and issues.
* **Bug Fixes**
  * Improved classification for incomplete, interrupted, and unexpectedly terminated reviews.
  * Preserved detection of critical findings after review interruptions.
  * Checkpoint uploads remain fail-safe and do not introduce workflow failures.
* **Documentation**
  * Clarified review resumption, checkpoint uploads, cancellation behavior, and incomplete outcomes.
* **Tests**
  * Expanded coverage for artifact uploads, interruptions, credentials, and state preservation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->