### PR TITLE
fix(docker): bridge buf into app image until next tools digest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,11 +57,11 @@ RUN --mount=type=cache,target=/root/.cache/uv,sharing=locked \
 
 # New binaries land in docker/tools.Dockerfile, but this app image still
 # FROMs a digest-pinned tools image that will not contain them until the
-# next published digest. Bridge typos and spectral here so dogfood and
+# next published digest. Bridge typos, spectral, and buf here so dogfood and
 # the manifest-vs-image gate actually run them instead of failing with
 # binary_missing. No-op once the digest already has them on PATH.
 RUN chmod +x /app/scripts/utils/install-tools.sh && \
-    /app/scripts/utils/install-tools.sh --docker --tools typos,spectral
+    /app/scripts/utils/install-tools.sh --docker --tools typos,spectral,buf
 
 # hadolint ignore=DL3008
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(docker): bridge buf into app image until next tools digest
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What’s Changing

docker-ci has failed on every run of `main` since #1155 merged (first red: run for `feat(tools): add buf`, 2026-08-28 05:33 UTC): the manifest-vs-image gate reports `buf: command failed with exit code 127`. The buf binary landed in `docker/tools.Dockerfile`, but the app image still `FROM`s the digest-pinned `lintro-tools` image published before buf existed — the exact gap the existing typos/spectral bridge documents.

One-line fix: add `buf` to the bridge (`install-tools.sh --docker --tools typos,spectral,buf`). It's a no-op once the next published tools digest contains buf.

Verified locally with `install-tools.sh --dry-run --tools buf` (resolves the pinned v1.71.0); the real image build is validated by this PR's docker-ci run per repo policy (no local Docker builds).

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated (n/a — covered by the existing manifest-vs-image CI gate)
- [ ] Docs updated if user-facing (n/a)
- [x] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Closes #2191
- Relates to #1155

## Details

Unblocks docker-ci for every open PR, including the #2176 epic phase PRs (currently #2189 is red only on this gate and its downstream no-silent-skip gate).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `buf` to the tools available in the Docker image.
* **Improvements**
  * Preserved conditional installation behavior for tools that are already available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
