### PR TITLE
refactor(tools): split manifest.json into committed source and generated output

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,6 +6,9 @@ include pyproject.toml
 recursive-include assets *
 recursive-include lintro/ascii-art *
 recursive-include lintro/tools *.json
+# Generator input, not a distributable artifact (#2178); the rendered
+# manifest.json is what ships. Mirrors [tool.setuptools.exclude-package-data].
+exclude lintro/tools/manifest.src.json
 recursive-include lintro/ai/prompts/templates *.md *.json
 
 # Include any additional documentation

--- a/docs/contributing/adding-a-new-tool.md
+++ b/docs/contributing/adding-a-new-tool.md
@@ -183,7 +183,9 @@ Choose the path that matches the tool's distribution mechanism.
    ```
 
 2. **`lintro/tools/manifest.json`** — add a tool entry (version must match
-   `_tool_versions.py`):
+   `_tool_versions.py`). Since #2178, hand-authored entries live in
+   `lintro/tools/manifest.src.json` (without a `version` key — the generator renders
+   `manifest.json` from it):
 
    ```json
    {

--- a/lintro/tools/manifest.src.json
+++ b/lintro/tools/manifest.src.json
@@ -1,0 +1,546 @@
+{
+  "version": 2,
+  "profiles": {
+    "minimal": {
+      "description": "Core Python linting only (fast CI)",
+      "tools": ["ruff", "black", "mypy", "bandit"]
+    },
+    "recommended": {
+      "description": "Project-appropriate tools based on detected languages",
+      "strategy": "auto-detect"
+    },
+    "complete": {
+      "description": "All supported tools",
+      "strategy": "all"
+    },
+    "full": {
+      "description": "All supported tools (alias for complete)",
+      "strategy": "all"
+    },
+    "python": {
+      "description": "Python linting and formatting tools",
+      "tools": ["ruff", "black", "mypy", "bandit", "pydoclint", "yamllint"]
+    },
+    "web": {
+      "description": "JavaScript and TypeScript tools",
+      "tools": ["prettier", "oxlint", "oxfmt", "tsc"]
+    },
+    "ci": {
+      "description": "Linters and security tools only (no formatters)",
+      "strategy": "filter",
+      "exclude_types": ["formatter"]
+    }
+  },
+  "language_map": {
+    "python": ["ruff", "black", "mypy", "bandit", "pydoclint", "semgrep", "pip_audit"],
+    "javascript": ["oxlint", "oxfmt", "prettier"],
+    "typescript": ["oxlint", "oxfmt", "prettier", "tsc"],
+    "rust": ["clippy", "rustfmt", "rustc", "cargo_audit", "cargo_deny"],
+    "go": ["golangci_lint", "semgrep"],
+    "ruby": ["semgrep"],
+    "sql": ["sqlfluff"],
+    "protobuf": ["buf"],
+    "shell": ["shellcheck", "shfmt"],
+    "docker": ["hadolint"],
+    "yaml": ["yamllint"],
+    "markdown": ["markdownlint", "vale"],
+    "html": ["html_validate"],
+    "toml": ["taplo"],
+    "dotenv": ["dotenv_linter"],
+    "css": ["stylelint"],
+    "scss": ["stylelint"],
+    "less": ["stylelint"],
+    "sass": ["stylelint"],
+    "github_actions": ["actionlint"],
+    "security": ["gitleaks", "osv_scanner", "semgrep", "trufflehog"],
+    "astro": ["astro_check", "prettier"],
+    "svelte": ["svelte_check", "prettier"],
+    "vue": ["vue_tsc", "prettier"],
+    "restructuredtext": ["vale"],
+    "asciidoc": ["vale"],
+    "plaintext": ["vale"]
+  },
+  "tools": [
+    {
+      "name": "actionlint",
+      "install": {
+        "type": "binary"
+      },
+      "tier": "tools",
+      "category": "external",
+      "version_command": ["actionlint", "--version"],
+      "languages": ["github_actions"],
+      "tags": ["linter"]
+    },
+    {
+      "name": "astro_check",
+      "min_version": "7.1.3",
+      "install": {
+        "type": "npm",
+        "package": "astro",
+        "bin": "astro"
+      },
+      "tier": "tools",
+      "category": "npm",
+      "version_command": ["astro", "--version"],
+      "languages": ["astro"],
+      "tags": ["linter"]
+    },
+    {
+      "name": "bandit",
+      "install": {
+        "type": "pip",
+        "package": "bandit"
+      },
+      "tier": "tools",
+      "category": "bundled",
+      "version_command": ["bandit", "--version"],
+      "languages": ["python"],
+      "tags": ["linter", "security"]
+    },
+    {
+      "name": "black",
+      "install": {
+        "type": "pip",
+        "package": "black"
+      },
+      "tier": "tools",
+      "category": "bundled",
+      "version_command": ["black", "--version"],
+      "languages": ["python"],
+      "tags": ["formatter"]
+    },
+    {
+      "name": "buf",
+      "install": {
+        "type": "binary"
+      },
+      "tier": "tools",
+      "category": "external",
+      "version_command": ["buf", "--version"],
+      "languages": ["protobuf"],
+      "tags": ["linter", "formatter"]
+    },
+    {
+      "name": "cargo_audit",
+      "install": {
+        "type": "cargo",
+        "package": "cargo-audit"
+      },
+      "tier": "tools",
+      "category": "external",
+      "version_command": ["cargo", "audit", "--version"],
+      "languages": ["rust"],
+      "tags": ["security"]
+    },
+    {
+      "name": "cargo_deny",
+      "install": {
+        "type": "cargo",
+        "package": "cargo-deny"
+      },
+      "tier": "tools",
+      "category": "external",
+      "version_command": ["cargo", "deny", "--version"],
+      "languages": ["rust"],
+      "tags": ["linter", "security"]
+    },
+    {
+      "name": "clippy",
+      "install": {
+        "type": "rustup",
+        "component": "clippy"
+      },
+      "tier": "tools",
+      "category": "external",
+      "version_command": ["cargo", "clippy", "--version"],
+      "languages": ["rust"],
+      "tags": ["linter"]
+    },
+    {
+      "name": "commitlint",
+      "install": {
+        "type": "npm",
+        "package": "@commitlint/cli"
+      },
+      "tier": "tools",
+      "category": "npm",
+      "version_command": ["commitlint", "--version"],
+      "languages": ["git"],
+      "tags": ["linter"]
+    },
+    {
+      "name": "dotenv_linter",
+      "install": {
+        "type": "binary"
+      },
+      "tier": "tools",
+      "category": "external",
+      "version_command": ["dotenv-linter", "--version"],
+      "languages": ["dotenv"],
+      "tags": ["linter"]
+    },
+    {
+      "name": "gitleaks",
+      "install": {
+        "type": "binary"
+      },
+      "tier": "tools",
+      "category": "external",
+      "version_command": ["gitleaks", "version"],
+      "languages": ["security"],
+      "tags": ["security"]
+    },
+    {
+      "name": "golangci_lint",
+      "install": {
+        "type": "binary"
+      },
+      "tier": "tools",
+      "category": "external",
+      "version_command": ["golangci-lint", "version"],
+      "languages": ["go"],
+      "tags": ["linter"]
+    },
+    {
+      "name": "hadolint",
+      "min_version": "2.14.0",
+      "install": {
+        "type": "binary"
+      },
+      "tier": "tools",
+      "category": "external",
+      "version_command": ["hadolint", "--version"],
+      "languages": ["docker"],
+      "tags": ["linter"]
+    },
+    {
+      "name": "html_validate",
+      "min_version": "11.5.6",
+      "install": {
+        "type": "npm",
+        "package": "html-validate"
+      },
+      "tier": "tools",
+      "category": "npm",
+      "version_command": ["html-validate", "--version"],
+      "languages": ["html"],
+      "tags": ["linter"]
+    },
+    {
+      "name": "markdownlint",
+      "install": {
+        "type": "npm",
+        "package": "markdownlint-cli2"
+      },
+      "tier": "tools",
+      "category": "npm",
+      "version_command": ["markdownlint-cli2", "--version"],
+      "languages": ["markdown"],
+      "tags": ["linter"]
+    },
+    {
+      "name": "mypy",
+      "install": {
+        "type": "pip",
+        "package": "mypy"
+      },
+      "tier": "tools",
+      "category": "bundled",
+      "version_command": ["mypy", "--version"],
+      "languages": ["python"],
+      "tags": ["linter", "type_checker"]
+    },
+    {
+      "name": "osv_scanner",
+      "min_version": "2.4.0",
+      "install": {
+        "type": "binary",
+        "package": "osv-scanner"
+      },
+      "tier": "tools",
+      "category": "external",
+      "version_command": ["osv-scanner", "--version"],
+      "languages": ["security"],
+      "tags": ["security"]
+    },
+    {
+      "name": "oxfmt",
+      "min_version": "0.60.0",
+      "install": {
+        "type": "npm",
+        "package": "oxfmt"
+      },
+      "tier": "tools",
+      "category": "npm",
+      "version_command": ["oxfmt", "--version"],
+      "languages": ["javascript", "typescript"],
+      "tags": ["formatter"]
+    },
+    {
+      "name": "oxlint",
+      "min_version": "1.75.0",
+      "install": {
+        "type": "npm",
+        "package": "oxlint"
+      },
+      "tier": "tools",
+      "category": "npm",
+      "version_command": ["oxlint", "--version"],
+      "languages": ["javascript", "typescript"],
+      "tags": ["linter"]
+    },
+    {
+      "name": "pip_audit",
+      "install": {
+        "type": "pip",
+        "package": "pip-audit"
+      },
+      "tier": "tools",
+      "category": "bundled",
+      "version_command": ["pip-audit", "--version"],
+      "languages": ["python"],
+      "tags": ["security"]
+    },
+    {
+      "name": "prettier",
+      "install": {
+        "type": "npm",
+        "package": "prettier"
+      },
+      "tier": "tools",
+      "category": "npm",
+      "version_command": ["prettier", "--version"],
+      "languages": ["javascript", "typescript", "astro", "svelte", "vue"],
+      "tags": ["formatter"]
+    },
+    {
+      "name": "pydoclint",
+      "install": {
+        "type": "pip",
+        "package": "pydoclint"
+      },
+      "tier": "tools",
+      "category": "bundled",
+      "version_command": ["pydoclint", "--version"],
+      "languages": ["python"],
+      "tags": ["linter"]
+    },
+    {
+      "name": "pytest",
+      "install": {
+        "type": "pip",
+        "package": "pytest"
+      },
+      "tier": "dev",
+      "category": "bundled",
+      "version_command": ["pytest", "--version"],
+      "languages": ["python"],
+      "tags": ["testing"]
+    },
+    {
+      "name": "ruff",
+      "install": {
+        "type": "pip",
+        "package": "ruff"
+      },
+      "tier": "tools",
+      "category": "bundled",
+      "version_command": ["ruff", "--version"],
+      "languages": ["python"],
+      "tags": ["linter", "formatter"]
+    },
+    {
+      "name": "rustc",
+      "install": {
+        "type": "rustup"
+      },
+      "tier": "tools",
+      "category": "external",
+      "version_command": ["rustc", "--version"],
+      "languages": ["rust"],
+      "tags": ["compiler"]
+    },
+    {
+      "name": "rustfmt",
+      "install": {
+        "type": "rustup",
+        "component": "rustfmt"
+      },
+      "tier": "tools",
+      "category": "external",
+      "version_command": ["rustfmt", "--version"],
+      "languages": ["rust"],
+      "tags": ["formatter"]
+    },
+    {
+      "name": "semgrep",
+      "install": {
+        "type": "pip",
+        "package": "semgrep"
+      },
+      "tier": "tools",
+      "category": "bundled",
+      "version_command": ["semgrep", "--version"],
+      "languages": ["python", "go", "ruby", "security"],
+      "tags": ["linter", "security"]
+    },
+    {
+      "name": "shellcheck",
+      "install": {
+        "type": "binary"
+      },
+      "tier": "tools",
+      "category": "external",
+      "version_command": ["shellcheck", "--version"],
+      "languages": ["shell"],
+      "tags": ["linter"]
+    },
+    {
+      "name": "shfmt",
+      "install": {
+        "type": "binary"
+      },
+      "tier": "tools",
+      "category": "external",
+      "version_command": ["shfmt", "--version"],
+      "languages": ["shell"],
+      "tags": ["formatter"]
+    },
+    {
+      "name": "spectral",
+      "install": {
+        "type": "npm",
+        "package": "@stoplight/spectral-cli"
+      },
+      "tier": "tools",
+      "category": "npm",
+      "version_command": ["spectral", "--version"],
+      "languages": ["openapi", "asyncapi", "json", "yaml"],
+      "tags": ["linter"]
+    },
+    {
+      "name": "sqlfluff",
+      "install": {
+        "type": "pip",
+        "package": "sqlfluff"
+      },
+      "tier": "tools",
+      "category": "bundled",
+      "version_command": ["sqlfluff", "--version"],
+      "languages": ["sql"],
+      "tags": ["linter"]
+    },
+    {
+      "name": "stylelint",
+      "install": {
+        "type": "npm",
+        "package": "stylelint",
+        "bin": "stylelint"
+      },
+      "tier": "tools",
+      "category": "npm",
+      "version_command": ["stylelint", "--version"],
+      "languages": ["css", "scss", "sass", "less"],
+      "tags": ["linter", "formatter"]
+    },
+    {
+      "name": "svelte_check",
+      "min_version": "4.7.3",
+      "install": {
+        "type": "npm",
+        "package": "svelte-check",
+        "bin": "svelte-check"
+      },
+      "tier": "tools",
+      "category": "npm",
+      "version_command": ["svelte-check", "--version"],
+      "languages": ["svelte"],
+      "tags": ["linter"]
+    },
+    {
+      "name": "taplo",
+      "install": {
+        "type": "binary"
+      },
+      "tier": "tools",
+      "category": "external",
+      "version_command": ["taplo", "--version"],
+      "languages": ["toml"],
+      "tags": ["linter", "formatter"]
+    },
+    {
+      "name": "trufflehog",
+      "install": {
+        "type": "binary"
+      },
+      "tier": "tools",
+      "category": "external",
+      "version_command": ["trufflehog", "--version"],
+      "languages": ["security"],
+      "tags": ["security"]
+    },
+    {
+      "name": "tsc",
+      "install": {
+        "type": "npm",
+        "package": "typescript",
+        "bin": "tsc"
+      },
+      "tier": "tools",
+      "category": "npm",
+      "version_command": ["tsc", "--version"],
+      "languages": ["typescript"],
+      "tags": ["linter", "type_checker"]
+    },
+    {
+      "name": "typos",
+      "install": {
+        "type": "cargo",
+        "package": "typos-cli"
+      },
+      "tier": "tools",
+      "category": "external",
+      "version_command": ["typos", "--version"],
+      "languages": ["text"],
+      "tags": ["linter"]
+    },
+    {
+      "name": "vale",
+      "min_version": "3.15.2",
+      "install": {
+        "type": "binary"
+      },
+      "tier": "tools",
+      "category": "external",
+      "version_command": ["vale", "--version"],
+      "languages": ["markdown", "restructuredtext", "asciidoc", "plaintext"],
+      "tags": ["linter", "documentation"]
+    },
+    {
+      "name": "vue_tsc",
+      "install": {
+        "type": "npm",
+        "package": "vue-tsc",
+        "bin": "vue-tsc"
+      },
+      "tier": "tools",
+      "category": "npm",
+      "version_command": ["bash", "scripts/ci/resolve-vue-tsc-version.sh"],
+      "languages": ["vue"],
+      "tags": ["linter", "type_checker"]
+    },
+    {
+      "name": "yamllint",
+      "install": {
+        "type": "pip",
+        "package": "yamllint"
+      },
+      "tier": "tools",
+      "category": "bundled",
+      "version_command": ["yamllint", "--version"],
+      "languages": ["yaml"],
+      "tags": ["linter"]
+    }
+  ]
+}

--- a/lintro_build/versions/generate.py
+++ b/lintro_build/versions/generate.py
@@ -1,11 +1,12 @@
 """Orchestration for the tool-version generator.
 
-Computes and writes ``lintro/_generated_versions.py`` and the ``version``
-fields of ``lintro/tools/manifest.json`` from the canonical sources. The seed
-mapping at ``lintro/_tool_packages.py`` declares which packages are tools (and
-which ``ToolName`` they own) and which are companions. Semgrep is read from
-``requirements-semgrep.txt`` instead of ``pyproject.toml`` so its resolver
-stays isolated (#2104).
+Computes and writes ``lintro/_generated_versions.py`` and renders
+``lintro/tools/manifest.json`` from the hand-authored
+``lintro/tools/manifest.src.json`` plus the canonical version sources. The
+seed mapping at ``lintro/_tool_packages.py`` declares which packages are
+tools (and which ``ToolName`` they own) and which are companions. Semgrep is
+read from ``requirements-semgrep.txt`` instead of ``pyproject.toml`` so its
+resolver stays isolated (#2104).
 
 Modes:
     default: write outputs, exit 0.
@@ -22,6 +23,7 @@ import argparse
 import difflib
 import json
 import sys
+from pathlib import Path
 
 from ..exit_codes import EXIT_DRIFT, EXIT_INPUT_ERROR, EXIT_OK
 from .errors import GenerationError
@@ -47,17 +49,19 @@ REQUIREMENTS_PYPI_SOURCES: dict[str, str] = {
 }
 
 
-def collect_outputs(seed: Seed, paths: GeneratorPaths) -> tuple[str, str, str]:
+def collect_outputs(seed: Seed, paths: GeneratorPaths) -> tuple[str, str]:
     """Compute desired ``_generated_versions.py`` and ``manifest.json`` text.
+
+    The manifest is rendered from the hand-authored ``manifest.src.json``
+    plus the resolved versions; the committed ``manifest.json`` is a pure
+    output and never read here.
 
     Args:
         seed: Parsed seed mapping.
         paths: Generator input/output paths.
 
     Returns:
-        Tuple of (generated module text, desired manifest text, current
-        manifest text). The current text is returned so callers can diff
-        without re-reading the manifest.
+        Tuple of (generated module text, rendered manifest text).
 
     Raises:
         GenerationError: If any input is missing, malformed, or inconsistent.
@@ -100,14 +104,18 @@ def collect_outputs(seed: Seed, paths: GeneratorPaths) -> tuple[str, str, str]:
     binary_versions = read_binary_tool_versions(paths.tool_versions_path)
 
     try:
-        manifest_current = paths.manifest_path.read_text()
-        manifest_data = json.loads(manifest_current)
+        manifest_src = paths.manifest_src_path.read_text()
+        manifest_src_data = json.loads(manifest_src)
     except OSError as exc:
-        raise GenerationError(f"manifest.json could not be read: {exc}") from exc
+        raise GenerationError(
+            f"manifest.src.json could not be read: {exc}",
+        ) from exc
     except json.JSONDecodeError as exc:
-        raise GenerationError(f"manifest.json is not valid JSON: {exc}") from exc
+        raise GenerationError(
+            f"manifest.src.json is not valid JSON: {exc}",
+        ) from exc
     target_versions = build_target_versions(
-        manifest_data=manifest_data,
+        manifest_data=manifest_src_data,
         npm_versions=npm_versions,
         pypi_versions=pypi_versions,
         binary_versions=binary_versions,
@@ -115,8 +123,8 @@ def collect_outputs(seed: Seed, paths: GeneratorPaths) -> tuple[str, str, str]:
     validate_seed_coverage(seed, target_versions)
 
     generated_text = render_generated_module(npm_versions, pypi_versions)
-    manifest_text = render_manifest(manifest_current, target_versions)
-    return generated_text, manifest_text, manifest_current
+    manifest_text = render_manifest(manifest_src, target_versions)
+    return generated_text, manifest_text
 
 
 def diff_text(label: str, current: str, desired: str) -> str:
@@ -167,11 +175,9 @@ def main(
 
     try:
         seed = parse_seed(paths.seed_path)
-        generated_text, manifest_text, current_manifest = collect_outputs(
-            seed,
-            paths,
-        )
-        current_generated = _read_current_generated(paths)
+        generated_text, manifest_text = collect_outputs(seed, paths)
+        current_generated = _read_current_output(paths.generated_path)
+        current_manifest = _read_current_output(paths.manifest_path)
     except GenerationError as exc:
         print(f"error: {exc}", file=sys.stderr)
         return EXIT_INPUT_ERROR
@@ -204,26 +210,24 @@ def main(
     return EXIT_OK
 
 
-def _read_current_generated(paths: GeneratorPaths) -> str:
-    """Read the committed generated-module text for diffing.
+def _read_current_output(path: Path) -> str:
+    """Read a generated output file's current text for diffing.
 
     Args:
-        paths: Generator input/output paths.
+        path: Path of the generated output file.
 
     Returns:
-        Current ``_generated_versions.py`` contents, or empty when the file
-        does not exist yet.
+        Current contents, or empty when the file does not exist yet (an
+        absent output is simply "everything is new", not an input error).
 
     Raises:
         GenerationError: If the path exists but cannot be read (e.g. it is a
             directory), so the failure surfaces as exit code 2 rather than an
             unhandled ``OSError``.
     """
-    if not paths.generated_path.exists():
+    if not path.exists():
         return ""
     try:
-        return paths.generated_path.read_text()
+        return path.read_text()
     except OSError as exc:
-        raise GenerationError(
-            f"_generated_versions.py could not be read: {exc}",
-        ) from exc
+        raise GenerationError(f"{path.name} could not be read: {exc}") from exc

--- a/lintro_build/versions/outputs.py
+++ b/lintro_build/versions/outputs.py
@@ -147,11 +147,31 @@ def render_manifest(src_text: str, target_versions: dict[str, str]) -> str:
     text = src_text
     for name, version in target_versions.items():
         pattern = re.compile(
-            rf'^(?P<indent>[ \t]*)"name": "{re.escape(name)}",\n',
+            rf'^(?P<indent>[ \t]*)"name": "{re.escape(name)}",(?P<nl>\r?\n)',
             re.MULTILINE,
         )
-        insertion = rf'\g<0>\g<indent>"version": "{version}",' + "\n"
-        text, count = pattern.subn(insertion, text)
+
+        def _insert(match: re.Match[str], version: str = version) -> str:
+            """Append a version line after the matched name line.
+
+            A callable replacement keeps the version string literal —
+            ``re.subn`` would otherwise interpret backslashes or group
+            references inside it. The matched line terminator is reused so
+            CRLF working trees (e.g. Windows checkouts under text=auto)
+            round-trip unchanged.
+
+            Args:
+                match: The matched ``"name": "..."`` line.
+                version: Resolved version for this tool.
+
+            Returns:
+                The matched text followed by the new version line.
+            """
+            indent = match.group("indent")
+            newline = match.group("nl")
+            return f'{match.group(0)}{indent}"version": "{version}",{newline}'
+
+        text, count = pattern.subn(_insert, text)
         if count == 0:
             raise GenerationError(
                 f"manifest.src.json has no '{name}' entry with a matching "

--- a/lintro_build/versions/outputs.py
+++ b/lintro_build/versions/outputs.py
@@ -106,47 +106,62 @@ def build_target_versions(
     return targets
 
 
-def render_manifest(current_text: str, target_versions: dict[str, str]) -> str:
-    """Apply targeted ``version`` updates to ``manifest.json`` text.
+def render_manifest(src_text: str, target_versions: dict[str, str]) -> str:
+    """Render ``manifest.json`` text from ``manifest.src.json`` text.
 
-    Edits only the ``"version": "..."`` field in each target tool object after
-    that tool's ``"name"`` field. All other bytes of the file (whitespace,
-    key order, inline-array formatting) are preserved — round-tripping
-    through ``json.dumps`` would reflow inline arrays into a noisy diff.
+    Inserts a ``"version": "..."`` field for each target tool immediately
+    after that tool's ``"name"`` field, matching the name line's indentation.
+    All other bytes of the source (whitespace, key order, inline-array
+    formatting) are preserved — round-tripping through ``json.dumps`` would
+    reflow inline arrays into a noisy diff.
 
     Args:
-        current_text: Current manifest.json contents.
+        src_text: Hand-authored manifest.src.json contents (no tool
+            ``version`` keys).
         target_versions: Mapping of manifest entry name -> desired version.
 
     Returns:
-        New manifest.json text.
+        Rendered manifest.json text.
 
     Raises:
-        GenerationError: If the manifest is malformed, a target name has no
-            following ``version`` field, or appears more than once.
+        GenerationError: If the source is malformed, contains a tool-level
+            ``version`` key (split-brain guard), or a target name matches
+            zero or multiple ``name`` fields.
     """
     try:
-        json.loads(current_text)
+        src_data = json.loads(src_text)
     except json.JSONDecodeError as exc:
-        raise GenerationError(f"manifest.json is not valid JSON: {exc}") from exc
+        raise GenerationError(f"manifest.src.json is not valid JSON: {exc}") from exc
 
-    text = current_text
+    versioned = [
+        entry.get("name", "<unnamed>")
+        for entry in src_data.get("tools", [])
+        if isinstance(entry, dict) and "version" in entry
+    ]
+    if versioned:
+        raise GenerationError(
+            f"manifest.src.json must not contain tool 'version' keys; the "
+            f"generator owns them. Remove the version from: {versioned}.",
+        )
+
+    text = src_text
     for name, version in target_versions.items():
         pattern = re.compile(
-            rf'("name":\s*"{re.escape(name)}".*?"version":\s*")[^"]+(")',
-            re.DOTALL,
+            rf'^(?P<indent>[ \t]*)"name": "{re.escape(name)}",\n',
+            re.MULTILINE,
         )
-        text, count = pattern.subn(rf"\g<1>{version}\g<2>", text)
+        insertion = rf'\g<0>\g<indent>"version": "{version}",' + "\n"
+        text, count = pattern.subn(insertion, text)
         if count == 0:
             raise GenerationError(
-                f"manifest.json has no '{name}' entry with a following version "
-                f"field. Add the entry, or restore the conventional "
-                f"name-before-version key order.",
+                f"manifest.src.json has no '{name}' entry with a matching "
+                f"name field. Add the entry, or restore the conventional "
+                f'one-per-line ``"name": "..."`` formatting.',
             )
         if count > 1:
             raise GenerationError(
-                f"manifest.json has multiple '{name}' entries; this should be "
-                f"impossible. Inspect the file.",
+                f"manifest.src.json has multiple '{name}' entries; this "
+                f"should be impossible. Inspect the file.",
             )
 
     return text

--- a/lintro_build/versions/paths.py
+++ b/lintro_build/versions/paths.py
@@ -17,7 +17,10 @@ class GeneratorPaths:
         tool_versions_path: Binary tool pins at ``lintro/_tool_versions.py``.
         package_json_path: npm pins at ``package.json``.
         pyproject_path: pypi pins at ``pyproject.toml``.
-        manifest_path: Manifest at ``lintro/tools/manifest.json``.
+        manifest_src_path: Hand-authored manifest source at
+            ``lintro/tools/manifest.src.json`` (no tool version keys).
+        manifest_path: Rendered manifest output at
+            ``lintro/tools/manifest.json``.
         generated_path: Output module at ``lintro/_generated_versions.py``.
     """
 
@@ -26,6 +29,7 @@ class GeneratorPaths:
     tool_versions_path: Path
     package_json_path: Path
     pyproject_path: Path
+    manifest_src_path: Path
     manifest_path: Path
     generated_path: Path
 
@@ -45,6 +49,7 @@ class GeneratorPaths:
             tool_versions_path=repo_root / "lintro" / "_tool_versions.py",
             package_json_path=repo_root / "package.json",
             pyproject_path=repo_root / "pyproject.toml",
+            manifest_src_path=repo_root / "lintro" / "tools" / "manifest.src.json",
             manifest_path=repo_root / "lintro" / "tools" / "manifest.json",
             generated_path=repo_root / "lintro" / "_generated_versions.py",
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -234,6 +234,14 @@ lintro = ["tools/*.json"]
 "lintro.ai.prompts.templates" = ["**/*.md", "**/*.json"]
 "lintro.ai.review.checklist" = ["corpus/*.yaml"]
 
+[tool.setuptools.exclude-package-data]
+# manifest.src.json is the hand-authored source the generator renders
+# manifest.json from (#2178); only the rendered manifest ships in the wheel.
+# This filters the ``tools/*.json`` package-data glob; MANIFEST.in carries a
+# matching ``exclude`` because setuptools does not apply this filter to
+# files pulled in via the sdist manifest (include-package-data path).
+lintro = ["tools/manifest.src.json"]
+
 [tool.ruff]
 line-length = 88
 target-version = "py311"

--- a/tests/scripts/generate_tool_versions/conftest.py
+++ b/tests/scripts/generate_tool_versions/conftest.py
@@ -82,18 +82,16 @@ dependencies = ["pytest>=9.0.3"]
 """,
     )
 
-    (tmp_path / "lintro" / "tools" / "manifest.json").write_text(
+    (tmp_path / "lintro" / "tools" / "manifest.src.json").write_text(
         json.dumps(
             {
                 "tools": [
                     {
                         "name": "oxfmt",
-                        "version": "0.0.0",
                         "install": {"type": "npm", "package": "oxfmt"},
                     },
                     {
                         "name": "pytest",
-                        "version": "0.0.0",
                         "install": {"type": "pip", "package": "pytest"},
                     },
                 ],

--- a/tests/scripts/generate_tool_versions/test_main.py
+++ b/tests/scripts/generate_tool_versions/test_main.py
@@ -46,21 +46,21 @@ def test_main_reads_semgrep_from_requirements_file(
         ),
     )
     (fake_repo / "requirements-semgrep.txt").write_text("semgrep==9.9.9\n")
-    manifest_path = fake_repo / "lintro" / "tools" / "manifest.json"
-    data = json.loads(manifest_path.read_text())
+    src_path = fake_repo / "lintro" / "tools" / "manifest.src.json"
+    data = json.loads(src_path.read_text())
     data["tools"].append(
         {
             "name": "semgrep",
-            "version": "0.0.0",
             "install": {"type": "pip", "package": "semgrep"},
         },
     )
-    manifest_path.write_text(json.dumps(data, indent=2) + "\n")
+    src_path.write_text(json.dumps(data, indent=2) + "\n")
 
     rc = retargeted_gen.main([])
     assert_that(rc).is_equal_to(retargeted_gen.EXIT_OK)
     generated = (fake_repo / "lintro" / "_generated_versions.py").read_text()
     assert_that(generated).contains('"semgrep": "9.9.9"')
+    manifest_path = fake_repo / "lintro" / "tools" / "manifest.json"
     assert_that(manifest_path.read_text()).contains('"version": "9.9.9"')
 
 
@@ -151,40 +151,62 @@ def test_main_input_error_exits_two(
     assert_that(capsys.readouterr().err).contains("oxfmt")
 
 
-def test_main_missing_manifest_exits_two(
+def test_main_missing_manifest_src_exits_two(
     retargeted_gen: SimpleNamespace,
     fake_repo: Path,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    """A missing manifest yields exit code 2, not an unhandled ``OSError``.
+    """A missing manifest source yields exit code 2, not an ``OSError``.
 
     Args:
         retargeted_gen: Generator module pointed at the fake repo.
         fake_repo: Fake repo fixture root.
         capsys: Pytest stdout/stderr capture.
     """
-    (fake_repo / "lintro" / "tools" / "manifest.json").unlink()
+    (fake_repo / "lintro" / "tools" / "manifest.src.json").unlink()
 
     rc = retargeted_gen.main([])
     assert_that(rc).is_equal_to(retargeted_gen.EXIT_INPUT_ERROR)
-    assert_that(capsys.readouterr().err).contains("manifest.json")
+    assert_that(capsys.readouterr().err).contains("manifest.src.json")
 
 
-def test_main_invalid_manifest_exits_two(
+def test_main_version_key_in_src_exits_two(
     retargeted_gen: SimpleNamespace,
     fake_repo: Path,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    """Malformed manifest JSON yields exit code 2.
+    """A tool ``version`` key in the manifest source yields exit code 2.
 
     Args:
         retargeted_gen: Generator module pointed at the fake repo.
         fake_repo: Fake repo fixture root.
         capsys: Pytest stdout/stderr capture.
     """
-    manifest = fake_repo / "lintro" / "tools" / "manifest.json"
-    manifest.write_text('{"tools": [')
+    src_path = fake_repo / "lintro" / "tools" / "manifest.src.json"
+    data = json.loads(src_path.read_text())
+    data["tools"][0]["version"] = "0.0.0"
+    src_path.write_text(json.dumps(data, indent=2) + "\n")
 
     rc = retargeted_gen.main([])
     assert_that(rc).is_equal_to(retargeted_gen.EXIT_INPUT_ERROR)
-    assert_that(capsys.readouterr().err).contains("manifest.json")
+    assert_that(capsys.readouterr().err).contains("oxfmt")
+
+
+def test_main_invalid_manifest_src_exits_two(
+    retargeted_gen: SimpleNamespace,
+    fake_repo: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Malformed manifest source JSON yields exit code 2.
+
+    Args:
+        retargeted_gen: Generator module pointed at the fake repo.
+        fake_repo: Fake repo fixture root.
+        capsys: Pytest stdout/stderr capture.
+    """
+    src_path = fake_repo / "lintro" / "tools" / "manifest.src.json"
+    src_path.write_text('{"tools": [')
+
+    rc = retargeted_gen.main([])
+    assert_that(rc).is_equal_to(retargeted_gen.EXIT_INPUT_ERROR)
+    assert_that(capsys.readouterr().err).contains("manifest.src.json")

--- a/tests/scripts/generate_tool_versions/test_outputs.py
+++ b/tests/scripts/generate_tool_versions/test_outputs.py
@@ -28,65 +28,85 @@ def test_render_generated_module_is_sorted(gen: ModuleType) -> None:
     )
 
 
-def test_render_manifest_preserves_inline_arrays(gen: ModuleType) -> None:
-    """Manifest update edits only ``version`` strings, not formatting.
+_SRC_MANIFEST = (
+    "{\n"
+    '  "language_map": ["python", "js", "ts"],\n'
+    '  "tools": [\n'
+    "    {\n"
+    '      "name": "oxfmt",\n'
+    '      "install": {"type": "npm", "package": "oxfmt"}\n'
+    "    },\n"
+    "    {\n"
+    '      "name": "pytest",\n'
+    '      "description": "test runner",\n'
+    '      "install": {"type": "pip", "package": "pytest"}\n'
+    "    }\n"
+    "  ]\n"
+    "}\n"
+)
+
+
+def test_render_manifest_inserts_versions_byte_stable(gen: ModuleType) -> None:
+    """Versions are inserted after each name; every other byte is preserved.
 
     Args:
         gen: Imported generator module.
     """
-    inline = (
+    new_text = gen.render_manifest(
+        src_text=_SRC_MANIFEST,
+        target_versions={"oxfmt": "0.43.0", "pytest": "9.0.3"},
+    )
+
+    assert_that(new_text).is_equal_to(
         "{\n"
         '  "language_map": ["python", "js", "ts"],\n'
         '  "tools": [\n'
         "    {\n"
         '      "name": "oxfmt",\n'
-        '      "version": "0.0.0",\n'
+        '      "version": "0.43.0",\n'
         '      "install": {"type": "npm", "package": "oxfmt"}\n'
         "    },\n"
         "    {\n"
         '      "name": "pytest",\n'
-        '      "version": "0.0.0",\n'
+        '      "version": "9.0.3",\n'
+        '      "description": "test runner",\n'
         '      "install": {"type": "pip", "package": "pytest"}\n'
         "    }\n"
         "  ]\n"
-        "}\n"
-    )
-    new_text = gen.render_manifest(
-        current_text=inline,
-        target_versions={"oxfmt": "0.43.0", "pytest": "9.0.3"},
+        "}\n",
     )
 
-    assert_that(new_text).contains('"language_map": ["python", "js", "ts"]')
-    assert_that(new_text).contains('"version": "0.43.0"')
-    assert_that(new_text).contains('"version": "9.0.3"')
 
-
-def test_render_manifest_allows_intervening_fields(gen: ModuleType) -> None:
-    """Manifest update tolerates metadata between name and version.
+def test_render_manifest_skips_untargeted_tools(gen: ModuleType) -> None:
+    """A src tool with no resolved version gets no version key.
 
     Args:
         gen: Imported generator module.
     """
-    manifest = (
-        "{\n"
-        '  "tools": [\n'
-        "    {\n"
-        '      "name": "oxfmt",\n'
-        '      "description": "formatter",\n'
-        '      "version": "0.0.0",\n'
-        '      "install": {"type": "npm", "package": "oxfmt"}\n'
-        "    }\n"
-        "  ]\n"
-        "}\n"
-    )
-
     new_text = gen.render_manifest(
-        current_text=manifest,
+        src_text=_SRC_MANIFEST,
         target_versions={"oxfmt": "0.43.0"},
     )
 
-    assert_that(new_text).contains('"description": "formatter"')
     assert_that(new_text).contains('"version": "0.43.0"')
+    assert_that(new_text.count('"version"')).is_equal_to(1)
+
+
+def test_render_manifest_rejects_version_in_src(gen: ModuleType) -> None:
+    """A tool ``version`` key in the source is a split-brain error.
+
+    Args:
+        gen: Imported generator module.
+    """
+    src = (
+        "{\n"
+        '  "tools": [\n'
+        '    {"name": "oxfmt", "version": "0.0.0"}\n'
+        "  ]\n"
+        "}\n"
+    )
+    with pytest.raises(gen.GenerationError, match="oxfmt"):
+        gen.render_manifest(src_text=src, target_versions={})
 
 
 def test_render_manifest_missing_entry_raises(gen: ModuleType) -> None:
@@ -97,7 +117,7 @@ def test_render_manifest_missing_entry_raises(gen: ModuleType) -> None:
     """
     with pytest.raises(gen.GenerationError, match="oxlint"):
         gen.render_manifest(
-            current_text='{"tools": []}\n',
+            src_text='{"tools": []}\n',
             target_versions={"oxlint": "1.0.0"},
         )
 

--- a/tests/scripts/generate_tool_versions/test_outputs.py
+++ b/tests/scripts/generate_tool_versions/test_outputs.py
@@ -92,6 +92,23 @@ def test_render_manifest_skips_untargeted_tools(gen: ModuleType) -> None:
     assert_that(new_text.count('"version"')).is_equal_to(1)
 
 
+def test_render_manifest_preserves_crlf_terminators(gen: ModuleType) -> None:
+    """CRLF source text round-trips with CRLF on the inserted line.
+
+    Args:
+        gen: Imported generator module.
+    """
+    src = _SRC_MANIFEST.replace("\n", "\r\n")
+
+    new_text = gen.render_manifest(
+        src_text=src,
+        target_versions={"oxfmt": "0.43.0"},
+    )
+
+    assert_that(new_text).contains('"version": "0.43.0",\r\n')
+    assert_that("\n" in new_text.replace("\r\n", "")).is_false()
+
+
 def test_render_manifest_rejects_version_in_src(gen: ModuleType) -> None:
     """A tool ``version`` key in the source is a split-brain error.
 

--- a/tests/scripts/test_lintro_build_generate_all.py
+++ b/tests/scripts/test_lintro_build_generate_all.py
@@ -41,13 +41,12 @@ def fake_repo(tmp_path: Path) -> Path:
         json.dumps({"devDependencies": {"oxfmt": "^0.43.0"}}, indent=2),
     )
     (tmp_path / "pyproject.toml").write_text('[project]\nname = "fake"\n')
-    (tmp_path / "lintro" / "tools" / "manifest.json").write_text(
+    (tmp_path / "lintro" / "tools" / "manifest.src.json").write_text(
         json.dumps(
             {
                 "tools": [
                     {
                         "name": "oxfmt",
-                        "version": "0.0.0",
                         "install": {"type": "npm", "package": "oxfmt"},
                     },
                 ],


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  refactor(tools): split manifest.json into committed source and generated output
  ```

- Type:
  - [ ] feat (minor)
  - [ ] fix / perf (patch)
  - [ ] docs
  - [x] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What’s Changing

Phase 2 of 5 of the manifest-drift dissolve epic (#2176): split `lintro/tools/manifest.json` into its two natures.

- **`lintro/tools/manifest.src.json` (new, committed)** — the hand-authored truth (tool entries, `profiles`, `language_map`, install metadata) with **no tool `version` keys**; derived from the current manifest by a one-off script (40 version lines stripped, the top-level schema `"version": 2` retained).
- **`lintro/tools/manifest.json` (still committed this phase)** — rendered by the generator *from* the src file plus the version sources; no longer a generator input.
- `render_manifest` reworked from in-place regex substitution to **insertion**: each resolved version is inserted directly after its tool's `"name"` line, matching indentation and reusing the matched line terminator (CRLF-safe), via a callable replacement so version strings stay literal. Zero-match/multi-match per-name errors and `validate_seed_coverage` retained.
- **Split-brain guard**: any tool-level `version` key in `manifest.src.json` → exit 2.
- `GeneratorPaths` gains `manifest_src_path`; `manifest.json` is output-only (a missing output is "everything is new", not an input error).
- Packaging: the wheel ships only the rendered `manifest.json`. **Deviation from the issue text, discovered empirically:** `[tool.setuptools.exclude-package-data]` alone does not exclude files pulled in via `MANIFEST.in`/include-package-data (verified with a minimal setuptools-84 repro), so a paired `exclude` line in `MANIFEST.in` is required; both are in place and the sdist also ships only the rendered manifest — consistent with phase 4's rule that generator inputs stay out of the sdist.
- Docs: one-line pointer in `docs/contributing/adding-a-new-tool.md` (full rewrite is phase 5, #2181).

**Verified byte-identity:** `git diff` on `lintro/tools/manifest.json` is empty after regeneration; `--check` exits 0; a simulated `_tool_versions.py` bump makes `--check` exit 1 with the expected diff; `uv build` wheel and sdist listings contain `manifest.json` but not `manifest.src.json`.

## Checklist

- [x] Title follows Conventional Commits
- [x] Tests added/updated
- [x] Docs updated if user-facing
- [x] Local CI passed (`./scripts/local/run-tests.sh`)

## Closes

- Closes #2178
- Relates to #2176

## Details

**Pre-push review set** (per epic merge bar):

- **CodeRabbit CLI** (1 finding): callable `re.subn` replacement — fixed.
- **lintro review** (cursor / grok-4.6; model returned unstructured output, findings recovered from the preserved answer): CRLF terminator preservation — fixed with a unit test; docs checklist still mixing src/generated manifest — deferred to phase 5 per epic scope; wheel/sdist membership test — not added: the referenced `test_built_package.py` does not exist in the tree, and phase 4's validation criteria mandate artifact-content acceptance tests when packaging is reworked; untargeted src tools shipping without versions — dismissed: the phase spec pins "existing skip/coverage semantics unchanged" (candidate hardening for phase 4).
- **Greptile CLI**: rate-limited (`free_reviews_limit_reached`); the other two passes are the pre-push review of record.

**Testing:** full suite green locally (10,731 passed); the deselected failures are machine-environmental (stale local golangci-lint etc.), each verified to fail identically on clean `origin/main`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a comprehensive tool registry covering linting profiles, language mappings, installation methods, supported versions, and tool categories.
  - Tool versions are now automatically populated in generated distribution manifests.

- **Bug Fixes**
  - Improved validation for malformed or invalid tool manifests, including duplicate tools, missing names, and misplaced version entries.
  - Preserved manifest formatting and line endings during generation.

- **Documentation**
  - Updated contributor guidance to explain the new source-manifest workflow and version generation process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->