### PR TITLE
fix(ci): regenerate builtin index before the universal-binary smoke test

### DIFF
--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -495,17 +495,28 @@ jobs:
             uploads.github.com:443
 
       # Needed for scripts/build/create_universal.sh and the binary smoke
-      # test (scripts/ci/smoke-test-binary.py reads the generated builtin
-      # index under lintro/plugins). The codeload /
-      # objects.githubusercontent.com endpoints above are what actions/checkout
-      # fetches through, and match the other sparse-checkout jobs here.
+      # test. smoke-test-binary.py reads lintro/plugins/_builtin_index.py,
+      # which is no longer committed (#2180), so the checkout carries the
+      # builtin-index generator's inputs instead: lintro/tools/definitions
+      # (the modules it scans) and the lintro_build package (the
+      # implementation). The codeload / objects.githubusercontent.com
+      # endpoints above are what actions/checkout fetches through, and match
+      # the other sparse-checkout jobs here.
       - name: Checkout scripts
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           sparse-checkout: |
             scripts
             lintro/plugins
+            lintro/tools/definitions
+            lintro_build
           persist-credentials: false
+
+      # #2202: regenerate the builtin index the smoke test reads; the file
+      # stopped being committed in #2180 and this job never builds the
+      # package, so nothing else generates it. Stdlib-only and offline.
+      - name: Generate builtin tool index
+        run: python3 scripts/ci/generate-builtin-tool-index.py
 
       - name: Download arm64 binary
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8

--- a/tests/unit/test_workflow_wiring.py
+++ b/tests/unit/test_workflow_wiring.py
@@ -2209,6 +2209,21 @@ def test_create_universal_binary_smoke_tests_the_post_lipo_artifact() -> None:
     sparse = checkout["with"]["sparse-checkout"]
     assert_that(sparse).contains("scripts")
     assert_that(sparse).contains("lintro/plugins")
+    # #2202: the builtin index is generated, not committed (#2180), and this
+    # job never builds the package — the checkout must carry the generator's
+    # inputs and the generate step must run between checkout and smoke test.
+    assert_that(sparse).contains("lintro/tools/definitions")
+    assert_that(sparse).contains("lintro_build")
+    generate = by_name["Generate builtin tool index"]
+    assert_that(generate["run"]).is_equal_to(
+        "python3 scripts/ci/generate-builtin-tool-index.py",
+    )
+    assert_that(names.index("Checkout scripts")).is_less_than(
+        names.index("Generate builtin tool index"),
+    )
+    assert_that(names.index("Generate builtin tool index")).is_less_than(
+        names.index("Smoke-test tool registry"),
+    )
 
     assert_that(
         job["timeout-minutes"] - smoke["timeout-minutes"],


### PR DESCRIPTION
## Commit Summary (Conventional Commits)

- Title (required, present tense):

  ```text
  fix(ci): regenerate builtin index before the universal-binary smoke test
  ```

- Type:
  - [ ] feat (minor)
  - [x] fix / perf (patch)
  - [ ] docs
  - [ ] refactor
  - [ ] test
  - [ ] chore / ci / style

- Breaking change:
  - [ ] `!` in title or `BREAKING CHANGE:` footer included

## What’s Changing

The first release after epic #2176's flip (0.137.0) failed in the universal-binary leg of the publish pipeline: the "Smoke-test tool registry" step could not read `lintro/plugins/_builtin_index.py` ([failing run](https://github.com/lgtm-hq/py-lintro/actions/runs/33233004742/job/99074160455)).

The universal-binary job in `build-binary.yml` sparse-checks-out only `scripts` + `lintro/plugins` and never builds the package — it downloads the two per-arch binaries, runs lipo, and smoke-tests the result. Pre-#2180 the builtin index was committed, so the sparse checkout contained it; post-#2180 it is generated at build time and nothing in this job generates it. The leg only runs with `arch == universal` during release publishing, which is why #2179's consumer sweep and PR-level CI never surfaced it.

Changes:

- Extend the job's sparse checkout with the builtin-index generator's inputs: `lintro/tools/definitions` (the modules it scans) and `lintro_build` (the implementation).
- Add a "Generate builtin tool index" step (`python3 scripts/ci/generate-builtin-tool-index.py`, stdlib-only and offline — no harden-runner endpoint changes needed) before the smoke test.
- Update the checkout step's comment to describe the new arrangement.

Part of #2176.

## Checklist

- [x] Title follows Conventional Commits
- [ ] Tests added/updated (workflow-only change; the generator and smoke test keep their existing suites)
- [ ] Docs updated if user-facing (not user-facing)
- [x] Local CI passed (`uv run lintro fmt && uv run lintro chk` green; full `uv run pytest` run — 418 passed, 3 pre-existing local-environment failures unrelated to this change, see Details)

## Closes

- Closes #2202
- Relates to #2176

## Details

Verified locally that `lintro_build.builtin_index.resolve_paths()` reads exactly `lintro/tools/definitions/` and writes `lintro/plugins/_builtin_index.py`, so the extended sparse checkout carries everything the generator needs. Only the builtin index is required in this job — the other two generated artifacts are not read here.

Full-suite pytest note: 3 integration tests fail on this machine on unmodified `main` as well (`golangci_lint`/`pip_audit` checks) because the locally installed binaries lag the freshly bumped pins (e.g. local golangci-lint 2.12.2 vs the new 2.13.0 minimum from the post-flip Renovate bump). They are environment staleness, not regressions from this diff, which touches only `.github/workflows/build-binary.yml`.

Sweep for other missed consumers (this conversation's audit): every other checkout-time consumer of the un-committed artifacts regenerates first (`docker-ci`, `dogfood-nightly`, per-arch binary builds via `build_linux/macos.py`, the Docker entrypoint) or reads `manifest.src.json`. This universal-binary leg was the only gap.

After merge: re-run the 0.137.0 publish workflow so the blocked Homebrew tap release ships.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved universal macOS binary builds by regenerating the built-in tool index before smoke testing.
  * Increased build reliability by including all required generator inputs in the build process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->